### PR TITLE
Use shorter type names

### DIFF
--- a/examples/abandon_a_message.rs
+++ b/examples/abandon_a_message.rs
@@ -7,11 +7,8 @@ async fn create_a_client_and_abandon_a_message() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a receiver and receive a message
     let mut receiver = client
@@ -34,11 +31,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and send a message
     let mut sender = client

--- a/examples/abandon_a_message.rs
+++ b/examples/abandon_a_message.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 
 /// Creates a separate client and receiver and then abandons a message.
 async fn create_a_client_and_abandon_a_message() -> Result<(), anyhow::Error> {
@@ -7,9 +7,9 @@ async fn create_a_client_and_abandon_a_message() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
@@ -34,9 +34,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 

--- a/examples/amqp_over_websocket.rs
+++ b/examples/amqp_over_websocket.rs
@@ -1,5 +1,5 @@
 use azservicebus::{
-    ServiceBusClient, ServiceBusClientOptions, ServiceBusSenderOptions, ServiceBusTransportType,
+    Client, ClientOptions, SenderOptions, TransportType,
 };
 
 #[tokio::main]
@@ -9,16 +9,16 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let options = ServiceBusClientOptions {
-        transport_type: ServiceBusTransportType::AmqpWebSocket,
+    let options = ClientOptions {
+        transport_type: TransportType::AmqpWebSocket,
         ..Default::default()
     };
     let mut client =
-        ServiceBusClient::new_from_connection_string(connection_string, options).await?;
+        Client::new_from_connection_string(connection_string, options).await?;
 
     // Create a sender for auth only
     let sender = client
-        .create_sender(queue_name, ServiceBusSenderOptions::default())
+        .create_sender(queue_name, SenderOptions::default())
         .await?;
 
     sender.dispose().await?;

--- a/examples/amqp_over_websocket.rs
+++ b/examples/amqp_over_websocket.rs
@@ -1,6 +1,4 @@
-use azservicebus::{
-    Client, ClientOptions, SenderOptions, TransportType,
-};
+use azservicebus::{Client, ClientOptions, SenderOptions, TransportType};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -13,8 +11,7 @@ async fn main() -> Result<(), anyhow::Error> {
         transport_type: TransportType::AmqpWebSocket,
         ..Default::default()
     };
-    let mut client =
-        Client::new_from_connection_string(connection_string, options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, options).await?;
 
     // Create a sender for auth only
     let sender = client

--- a/examples/auth_with_azure_identity.rs
+++ b/examples/auth_with_azure_identity.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions, ServiceBusSenderOptions};
+use azservicebus::{Client, ClientOptions, SenderOptions};
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 
 #[tokio::main]
@@ -10,16 +10,16 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
     let credential = DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
-    let mut client = ServiceBusClient::new_from_credential(
+    let mut client = Client::new_from_credential(
         namespace,
         credential,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
     // Create a sender for auth purpose only
     let sender = client
-        .create_sender(queue_name, ServiceBusSenderOptions::default())
+        .create_sender(queue_name, SenderOptions::default())
         .await?;
 
     sender.dispose().await?;

--- a/examples/auth_with_azure_identity.rs
+++ b/examples/auth_with_azure_identity.rs
@@ -10,12 +10,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
     let credential = DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
-    let mut client = Client::new_from_credential(
-        namespace,
-        credential,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_credential(namespace, credential, ClientOptions::default()).await?;
 
     // Create a sender for auth purpose only
     let sender = client

--- a/examples/auth_with_connection_string.rs
+++ b/examples/auth_with_connection_string.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions, ServiceBusSenderOptions};
+use azservicebus::{Client, ClientOptions, SenderOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -7,15 +7,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
     // Create a sender for auth purpose only
     let sender = client
-        .create_sender(queue_name, ServiceBusSenderOptions::default())
+        .create_sender(queue_name, SenderOptions::default())
         .await?;
 
     sender.dispose().await?;

--- a/examples/auth_with_connection_string.rs
+++ b/examples/auth_with_connection_string.rs
@@ -7,11 +7,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender for auth purpose only
     let sender = client

--- a/examples/auth_with_named_key.rs
+++ b/examples/auth_with_named_key.rs
@@ -1,7 +1,4 @@
-use azservicebus::{
-    authorization::AzureNamedKeyCredential, Client, ClientOptions,
-    SenderOptions,
-};
+use azservicebus::{authorization::AzureNamedKeyCredential, Client, ClientOptions, SenderOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -16,12 +13,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
     let credential = AzureNamedKeyCredential::new(sas_key_name, sas_key);
-    let mut client = Client::new_from_named_key_credential(
-        namespace,
-        credential,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_named_key_credential(namespace, credential, ClientOptions::default())
+            .await?;
 
     // Create a sender for auth purpose only
     let sender = client

--- a/examples/auth_with_named_key.rs
+++ b/examples/auth_with_named_key.rs
@@ -1,6 +1,6 @@
 use azservicebus::{
-    authorization::AzureNamedKeyCredential, ServiceBusClient, ServiceBusClientOptions,
-    ServiceBusSenderOptions,
+    authorization::AzureNamedKeyCredential, Client, ClientOptions,
+    SenderOptions,
 };
 
 #[tokio::main]
@@ -16,16 +16,16 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
     let credential = AzureNamedKeyCredential::new(sas_key_name, sas_key);
-    let mut client = ServiceBusClient::new_from_named_key_credential(
+    let mut client = Client::new_from_named_key_credential(
         namespace,
         credential,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
     // Create a sender for auth purpose only
     let sender = client
-        .create_sender(queue_name, ServiceBusSenderOptions::default())
+        .create_sender(queue_name, SenderOptions::default())
         .await?;
 
     sender.dispose().await?;

--- a/examples/cancel_a_scheduled_message.rs
+++ b/examples/cancel_a_scheduled_message.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 use time::OffsetDateTime;
 
 #[tokio::main]
@@ -8,9 +8,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
     let mut sender = client

--- a/examples/cancel_a_scheduled_message.rs
+++ b/examples/cancel_a_scheduled_message.rs
@@ -8,11 +8,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
     let mut sender = client
         .create_sender(&queue_name, Default::default())
         .await?;

--- a/examples/complete_a_message.rs
+++ b/examples/complete_a_message.rs
@@ -9,11 +9,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and send a message
     let mut sender = client

--- a/examples/complete_a_message.rs
+++ b/examples/complete_a_message.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -9,9 +9,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 

--- a/examples/dead_letter_a_message.rs
+++ b/examples/dead_letter_a_message.rs
@@ -1,6 +1,4 @@
-use azservicebus::{
-    Client, ClientOptions, ReceiverOptions, SubQueue,
-};
+use azservicebus::{Client, ClientOptions, ReceiverOptions, SubQueue};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -9,11 +7,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     let mut receiver = client
         .create_receiver_for_queue(&queue_name, Default::default())

--- a/examples/dead_letter_a_message.rs
+++ b/examples/dead_letter_a_message.rs
@@ -1,5 +1,5 @@
 use azservicebus::{
-    ServiceBusClient, ServiceBusClientOptions, ServiceBusReceiverOptions, SubQueue,
+    Client, ClientOptions, ReceiverOptions, SubQueue,
 };
 
 #[tokio::main]
@@ -9,9 +9,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
@@ -30,7 +30,7 @@ async fn main() -> Result<(), anyhow::Error> {
     receiver.dispose().await?;
 
     // Create a separate deadletter receiver to receive the dead-lettered message
-    let options = ServiceBusReceiverOptions {
+    let options = ReceiverOptions {
         sub_queue: SubQueue::DeadLetter,
         ..Default::default()
     };

--- a/examples/defer_a_message.rs
+++ b/examples/defer_a_message.rs
@@ -7,11 +7,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and send a message
     let mut sender = client

--- a/examples/defer_a_message.rs
+++ b/examples/defer_a_message.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -7,9 +7,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 

--- a/examples/manage_rules.rs
+++ b/examples/manage_rules.rs
@@ -1,7 +1,7 @@
 use azservicebus::administration::{
     CorrelationRuleFilter, FalseRuleFilter, SqlRuleAction, SqlRuleFilter, TrueRuleFilter,
 };
-use azservicebus::ServiceBusClient;
+use azservicebus::Client;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -12,7 +12,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let subscription_name = std::env::var("SERVICE_BUS_SUBSCRIPTION")?;
 
     let mut client =
-        ServiceBusClient::new_from_connection_string(connection_string, Default::default()).await?;
+        Client::new_from_connection_string(connection_string, Default::default()).await?;
     let mut rule_manager = client
         .create_rule_manager(topic_name, subscription_name)
         .await?;

--- a/examples/peek_a_message.rs
+++ b/examples/peek_a_message.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -11,9 +11,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 

--- a/examples/peek_a_message.rs
+++ b/examples/peek_a_message.rs
@@ -11,11 +11,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     let mut receiver = client
         .create_receiver_for_queue(queue_name, Default::default())

--- a/examples/receive_from_next_available_session.rs
+++ b/examples/receive_from_next_available_session.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions, ServiceBusMessage};
+use azservicebus::{Client, ClientOptions, Message};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -9,9 +9,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_SESSION_QUEUE")?;
     let session_id = "session1";
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
@@ -19,7 +19,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut sender = client
         .create_sender(&queue_name, Default::default())
         .await?;
-    let mut message = ServiceBusMessage::new("Hello World");
+    let mut message = Message::new("Hello World");
     message.set_session_id(String::from(session_id))?;
     sender.send_message(message).await?;
 

--- a/examples/receive_from_next_available_session.rs
+++ b/examples/receive_from_next_available_session.rs
@@ -9,11 +9,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_SESSION_QUEUE")?;
     let session_id = "session1";
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and send a session message
     let mut sender = client

--- a/examples/receive_messages.rs
+++ b/examples/receive_messages.rs
@@ -7,15 +7,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Replace "<NAMESPACE-CONNECTION-STRING>" with your connection string,
     // which can be found in the Azure portal and should look like
     // "Endpoint=sb://<NAMESPACE>.servicebus.windows.net/;SharedAccessKeyName=<KEY_NAME>;SharedAccessKey=<KEY_VALUE>"
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         "Endpoint=sb://azservicebus-testing.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=f+K8k7neAdg2e29A2bh12mwRCw5rdpKBR+ASbCSYfQ8=",
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
     // Replace "<QUEUE-NAME>" with the name of your queue
     let mut receiver = client
-        .create_receiver_for_queue("q1", ServiceBusReceiverOptions::default())
+        .create_receiver_for_queue("q1", ReceiverOptions::default())
         .await?;
 
     // Receive messages from the queue

--- a/examples/renew_message_lock.rs
+++ b/examples/renew_message_lock.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -7,9 +7,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
     let mut receiver = client

--- a/examples/renew_message_lock.rs
+++ b/examples/renew_message_lock.rs
@@ -7,11 +7,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, Default::default())
         .await?;

--- a/examples/schedule_a_message.rs
+++ b/examples/schedule_a_message.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions, ServiceBusMessage};
+use azservicebus::{Client, ClientOptions, Message};
 use time::OffsetDateTime;
 
 #[tokio::main]
@@ -8,9 +8,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
     let mut sender = client
@@ -18,13 +18,13 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     // Schedule message by setting the scheduled enqueue time
-    let mut message = ServiceBusMessage::new("Message 1");
+    let mut message = Message::new("Message 1");
     let enqueue_time = OffsetDateTime::now_utc() + time::Duration::minutes(1);
     message.set_scheduled_enqueue_time(enqueue_time);
     sender.send_message(message).await?;
 
     // Schedule message by using the schedule_message method
-    let message = ServiceBusMessage::new("Message 2");
+    let message = Message::new("Message 2");
     let enqueue_time = OffsetDateTime::now_utc() + time::Duration::minutes(1);
     let _sequence_number = sender.schedule_message(message, enqueue_time).await?;
 

--- a/examples/schedule_a_message.rs
+++ b/examples/schedule_a_message.rs
@@ -8,11 +8,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
     let mut sender = client
         .create_sender(&queue_name, Default::default())
         .await?;

--- a/examples/send_and_receive_message_batch.rs
+++ b/examples/send_and_receive_message_batch.rs
@@ -1,16 +1,16 @@
 use azservicebus::{
-    CreateMessageBatchOptions, ServiceBusClient, ServiceBusClientOptions, ServiceBusMessage,
-    ServiceBusReceiver, ServiceBusSender,
+    CreateMessageBatchOptions, Client, ClientOptions, Message,
+    Receiver, Sender,
 };
 
-async fn send_batch(mut sender: ServiceBusSender) -> Result<(), anyhow::Error> {
+async fn send_batch(mut sender: Sender) -> Result<(), anyhow::Error> {
     let mut batch = sender.create_message_batch(CreateMessageBatchOptions::default())?;
 
     // Add messages to the batch
     // The three lines below are all equivalent
     batch.try_add_message("Message 1")?;
-    batch.try_add_message(ServiceBusMessage::new("Message 2"))?;
-    batch.try_add_message(ServiceBusMessage::from("Message 3"))?;
+    batch.try_add_message(Message::new("Message 2"))?;
+    batch.try_add_message(Message::from("Message 3"))?;
 
     // Send the batch
     sender.send_message_batch(batch).await?;
@@ -19,7 +19,7 @@ async fn send_batch(mut sender: ServiceBusSender) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn receive_messages(mut receiver: ServiceBusReceiver) -> Result<(), anyhow::Error> {
+async fn receive_messages(mut receiver: Receiver) -> Result<(), anyhow::Error> {
     // This will wait indefinitely until at least one message is received
     let received = receiver.receive_messages(3).await?;
     for message in received {
@@ -38,9 +38,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 

--- a/examples/send_and_receive_message_batch.rs
+++ b/examples/send_and_receive_message_batch.rs
@@ -1,7 +1,4 @@
-use azservicebus::{
-    CreateMessageBatchOptions, Client, ClientOptions, Message,
-    Receiver, Sender,
-};
+use azservicebus::{Client, ClientOptions, CreateMessageBatchOptions, Message, Receiver, Sender};
 
 async fn send_batch(mut sender: Sender) -> Result<(), anyhow::Error> {
     let mut batch = sender.create_message_batch(CreateMessageBatchOptions::default())?;
@@ -38,11 +35,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and then send a batch of messages
     let sender = client

--- a/examples/send_and_receive_session_messages.rs
+++ b/examples/send_and_receive_session_messages.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions, ServiceBusMessage};
+use azservicebus::{Client, ClientOptions, Message};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -9,9 +9,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_SESSION_QUEUE")?;
     let session_id = "session1";
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
@@ -19,7 +19,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut sender = client
         .create_sender(&queue_name, Default::default())
         .await?;
-    let mut message = ServiceBusMessage::new("Hello World");
+    let mut message = Message::new("Hello World");
     message.set_session_id(String::from(session_id))?;
     sender.send_message(message).await?;
     sender.dispose().await?;

--- a/examples/send_and_receive_session_messages.rs
+++ b/examples/send_and_receive_session_messages.rs
@@ -9,11 +9,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let queue_name = std::env::var("SERVICE_BUS_SESSION_QUEUE")?;
     let session_id = "session1";
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and send a session message
     let mut sender = client

--- a/examples/send_and_receive_using_queue.rs
+++ b/examples/send_and_receive_using_queue.rs
@@ -1,4 +1,4 @@
-use azservicebus::{ServiceBusClient, ServiceBusClientOptions};
+use azservicebus::{Client, ClientOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -7,9 +7,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 

--- a/examples/send_and_receive_using_queue.rs
+++ b/examples/send_and_receive_using_queue.rs
@@ -7,11 +7,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and receiver
     let mut sender = client

--- a/examples/send_and_receive_using_topic_and_subscription.rs
+++ b/examples/send_and_receive_using_topic_and_subscription.rs
@@ -1,5 +1,5 @@
 use azservicebus::{
-    ServiceBusClient, ServiceBusClientOptions, ServiceBusReceiverOptions, ServiceBusSenderOptions,
+    Client, ClientOptions, ReceiverOptions, SenderOptions,
 };
 
 #[tokio::main]
@@ -10,19 +10,19 @@ async fn main() -> Result<(), anyhow::Error> {
     let topic_name = std::env::var("SERVICE_BUS_TOPIC")?;
     let subscription_name = std::env::var("SERVICE_BUS_SUBSCRIPTION")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
     let mut sender = client
-        .create_sender(&topic_name, ServiceBusSenderOptions::default())
+        .create_sender(&topic_name, SenderOptions::default())
         .await?;
     let mut receiver = client
         .create_receiver_for_subscription(
             topic_name,
             subscription_name,
-            ServiceBusReceiverOptions::default(),
+            ReceiverOptions::default(),
         )
         .await?;
 

--- a/examples/send_and_receive_using_topic_and_subscription.rs
+++ b/examples/send_and_receive_using_topic_and_subscription.rs
@@ -1,6 +1,4 @@
-use azservicebus::{
-    Client, ClientOptions, ReceiverOptions, SenderOptions,
-};
+use azservicebus::{Client, ClientOptions, ReceiverOptions, SenderOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -10,20 +8,13 @@ async fn main() -> Result<(), anyhow::Error> {
     let topic_name = std::env::var("SERVICE_BUS_TOPIC")?;
     let subscription_name = std::env::var("SERVICE_BUS_SUBSCRIPTION")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
     let mut sender = client
         .create_sender(&topic_name, SenderOptions::default())
         .await?;
     let mut receiver = client
-        .create_receiver_for_subscription(
-            topic_name,
-            subscription_name,
-            ReceiverOptions::default(),
-        )
+        .create_receiver_for_subscription(topic_name, subscription_name, ReceiverOptions::default())
         .await?;
 
     // Send one message

--- a/examples/send_messages.rs
+++ b/examples/send_messages.rs
@@ -7,15 +7,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Replace "<NAMESPACE-CONNECTION-STRING>" with your connection string,
     // which can be found in the Azure portal and should look like
     // "Endpoint=sb://<NAMESPACE>.servicebus.windows.net/;SharedAccessKeyName=<KEY_NAME>;SharedAccessKey=<KEY_VALUE>"
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         "<NAMESPACE-CONNECTION-STRING>",
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
     // Replace "<QUEUE-NAME>" with the name of your queue
     let mut sender = client
-        .create_sender("<QUEUE-NAME>", ServiceBusSenderOptions::default())
+        .create_sender("<QUEUE-NAME>", SenderOptions::default())
         .await?;
 
     // Create a batch
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 0..3 {
         // Create a message
-        let message = ServiceBusMessage::new(format!("Message {}", i));
+        let message = Message::new(format!("Message {}", i));
         // Try to add the message to the batch
         if let Err(e) = message_batch.try_add_message(message) {
             // If the batch is full, an error will be returned

--- a/examples/setting_ttl.rs
+++ b/examples/setting_ttl.rs
@@ -7,11 +7,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = Client::new_from_connection_string(
-        connection_string,
-        ClientOptions::default(),
-    )
-    .await?;
+    let mut client =
+        Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
     // Create a sender and then send a batch of messages
     let mut sender = client

--- a/examples/setting_ttl.rs
+++ b/examples/setting_ttl.rs
@@ -7,9 +7,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
     let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-    let mut client = ServiceBusClient::new_from_connection_string(
+    let mut client = Client::new_from_connection_string(
         connection_string,
-        ServiceBusClientOptions::default(),
+        ClientOptions::default(),
     )
     .await?;
 
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .create_sender(&queue_name, Default::default())
         .await?;
 
-    let mut message = ServiceBusMessage::new("test message 1");
+    let mut message = Message::new("test message 1");
     message.set_time_to_live(std::time::Duration::from_secs(10 * 60))?;
     sender.send_message(message).await?;
 

--- a/examples/wasm32_in_browser/src/lib.rs
+++ b/examples/wasm32_in_browser/src/lib.rs
@@ -26,7 +26,7 @@ async fn local_set_main() -> Result<(), Box<dyn std::error::Error>> {
 
     // This must be called within a `LocalSet` to work.
     let mut client =
-        ServiceBusClient::new_from_connection_string("<NAMESPACE-CONNECTION-STRING>", Default::default()).await?;
+        Client::new_from_connection_string("<NAMESPACE-CONNECTION-STRING>", Default::default()).await?;
     console::log_1(&"Client created".into());
 
     // This must be called within a `LocalSet` to work.

--- a/src/administration/rules/filters.rs
+++ b/src/administration/rules/filters.rs
@@ -14,11 +14,11 @@ use crate::amqp::{
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::ServiceBusMessage;
+use crate::Message;
 
 /// A [`SqlRuleFilter`] holds a SQL-like condition expression that is evaluated in the broker
 /// against the arriving messages' user-defined properties and system properties. All system
-/// properties (which are all properties explicitly listed on the [`ServiceBusMessage`]
+/// properties (which are all properties explicitly listed on the [`Message`]
 /// class) must be prefixed with `sys.` in the condition expression. The SQL subset
 /// implements testing for existence of properties (EXISTS), testing for null-values (IS NULL),
 /// logical NOT/AND/OR, relational operators, numeric arithmetic, and simple text pattern matching
@@ -64,11 +64,11 @@ impl SqlRuleFilter {
 ///
 /// A CorrelationRuleFilter holds a set of conditions that are matched against one of more of an
 /// arriving message's user and system properties. A common use is a match against the
-/// [`ServiceBusMessage::correlation_id`] property, but the application can also choose to match
-/// against [`ServiceBusMessage::content_type`], [`ServiceBusMessage::subject`],
-/// [`ServiceBusMessage::message_id`], [`ServiceBusMessage::reply_to`],
-/// [`ServiceBusMessage::reply_to_session_id`], [`ServiceBusMessage.session_id`],
-/// [`ServiceBusMessage.to()`, and any user-defined properties. A match exists when an arriving
+/// [`Message::correlation_id`] property, but the application can also choose to match
+/// against [`Message::content_type`], [`Message::subject`],
+/// [`Message::message_id`], [`Message::reply_to`],
+/// [`Message::reply_to_session_id`], [`Message.session_id`],
+/// [`Message.to()`, and any user-defined properties. A match exists when an arriving
 /// message's value for a property is equal to the value specified in the correlation filter. For
 /// string expressions, the comparison is case-sensitive. When specifying multiple match properties,
 /// the filter combines them as a logical AND condition, meaning all conditions must match for the

--- a/src/amqp/amqp_message_batch.rs
+++ b/src/amqp/amqp_message_batch.rs
@@ -55,10 +55,7 @@ impl TransportMessageBatch for AmqpMessageBatch {
         self.messages.is_empty()
     }
 
-    fn try_add_message(
-        &mut self,
-        message: crate::Message,
-    ) -> Result<(), Self::TryAddError> {
+    fn try_add_message(&mut self, message: crate::Message) -> Result<(), Self::TryAddError> {
         let serializable_message = Serializable(&message.amqp_message);
 
         // Initialize the size by reserving space for the batch envelope taking into account the

--- a/src/amqp/amqp_message_constants.rs
+++ b/src/amqp/amqp_message_constants.rs
@@ -18,11 +18,11 @@ pub(crate) const MESSAGE_STATE_NAME: &str = "x-opt-message-state";
 // concatcp!(amqp_constants::VENDOR, ":datetime-offset");
 
 /// Property key representing dead-letter reason, when a message is received from a dead-letter subqueue of an entity.
-/// This key and the associated values are stored in the [`ServiceBusReceivedMessage.application_properties`] dictionary
+/// This key and the associated values are stored in the [`ReceivedMessage.application_properties`] dictionary
 /// for dead lettered messages.
 pub(crate) const DEAD_LETTER_REASON_HEADER: &str = "DeadLetterReason";
 
 /// Property key representing detailed error description, when a message is received from a dead-letter subqueue of an entity.
-/// This key and the associated values are stored in the [`ServiceBusReceivedMessage.application_properties`] dictionary
+/// This key and the associated values are stored in the [`ReceivedMessage.application_properties`] dictionary
 /// for dead lettered messages.
 pub(crate) const DEAD_LETTER_ERROR_DESCRIPTION_HEADER: &str = "DeadLetterErrorDescription";

--- a/src/amqp/amqp_message_converter.rs
+++ b/src/amqp/amqp_message_converter.rs
@@ -3,11 +3,11 @@ use fe2o3_amqp::{
     Sendable,
 };
 use fe2o3_amqp_types::messaging::{
-    message::__private::Serializable, Batch, Data, Message, Outcome,
+    message::__private::Serializable, Batch, Data, Message as AmqpMessage, Outcome,
 };
 use serde_amqp::to_vec;
 
-use crate::ServiceBusMessage;
+use crate::Message;
 
 use super::amqp_constants;
 
@@ -53,7 +53,7 @@ pub(crate) struct BatchEnvelope {
 
 #[inline]
 pub(crate) fn batch_service_bus_messages_as_amqp_message(
-    source: impl ExactSizeIterator<Item = ServiceBusMessage>,
+    source: impl ExactSizeIterator<Item = Message>,
     force_batch: bool,
 ) -> Option<BatchEnvelope> {
     let batch_messages = source.map(|m| m.amqp_message);
@@ -64,7 +64,7 @@ pub(crate) fn batch_service_bus_messages_as_amqp_message(
 ///
 /// If `force_batch` is set to true, then a batch will be created even if there is only one message.
 pub(crate) fn build_amqp_batch_from_messages(
-    mut source: impl ExactSizeIterator<Item = Message<Data>>,
+    mut source: impl ExactSizeIterator<Item = AmqpMessage<Data>>,
     force_batch: bool,
 ) -> Option<BatchEnvelope> {
     let total = source.len();
@@ -101,7 +101,7 @@ pub(crate) fn build_amqp_batch_from_messages(
                 batch_data.push(data);
             }
 
-            let envelop = Message::builder()
+            let envelop = AmqpMessage::builder()
                 .body(batch_data)
                 .properties(properties)
                 .message_annotations(message_annotations)

--- a/src/amqp/amqp_response_message/peek_message.rs
+++ b/src/amqp/amqp_response_message/peek_message.rs
@@ -6,7 +6,7 @@ use fe2o3_amqp_types::primitives::{Binary, OrderedMap};
 use serde_amqp::Value;
 
 use crate::amqp::management_constants::properties::{MESSAGE, MESSAGES};
-use crate::primitives::service_bus_peeked_message::ServiceBusPeekedMessage;
+use crate::primitives::service_bus_peeked_message::PeekedMessage;
 
 use super::{HTTP_STATUS_CODE_NO_CONTENT, HTTP_STATUS_CODE_OK};
 
@@ -32,13 +32,13 @@ pub(crate) fn get_messages_from_body(
 }
 
 impl PeekMessageResponse {
-    pub fn into_peeked_messages(self) -> Result<Vec<ServiceBusPeekedMessage>, serde_amqp::Error> {
+    pub fn into_peeked_messages(self) -> Result<Vec<PeekedMessage>, serde_amqp::Error> {
         self.messages
             .into_iter()
             .map(|buf| {
                 let raw_amqp_message: Deserializable<Message<Body<Value>>> =
                     serde_amqp::from_slice(&buf)?;
-                let message = ServiceBusPeekedMessage {
+                let message = PeekedMessage {
                     raw_amqp_message: raw_amqp_message.0,
                 };
                 Ok(message)

--- a/src/amqp/amqp_response_message/peek_session_message.rs
+++ b/src/amqp/amqp_response_message/peek_session_message.rs
@@ -4,7 +4,7 @@ use serde_amqp::Value;
 
 use crate::{
     amqp::management_constants::properties::MESSAGES,
-    primitives::service_bus_peeked_message::ServiceBusPeekedMessage,
+    primitives::service_bus_peeked_message::PeekedMessage,
 };
 
 use super::{HTTP_STATUS_CODE_NO_CONTENT, HTTP_STATUS_CODE_OK};
@@ -17,13 +17,13 @@ pub(crate) struct PeekSessionMessageResponse {
 }
 
 impl PeekSessionMessageResponse {
-    pub fn into_peeked_messages(self) -> Result<Vec<ServiceBusPeekedMessage>, serde_amqp::Error> {
+    pub fn into_peeked_messages(self) -> Result<Vec<PeekedMessage>, serde_amqp::Error> {
         self.messages
             .into_iter()
             .map(|buf| {
                 let raw_amqp_message: Deserializable<Message<Body<Value>>> =
                     serde_amqp::from_slice(&buf)?;
-                let message = ServiceBusPeekedMessage {
+                let message = PeekedMessage {
                     raw_amqp_message: raw_amqp_message.0,
                 };
                 Ok(message)

--- a/src/amqp/amqp_response_message/receive_by_sequence_number.rs
+++ b/src/amqp/amqp_response_message/receive_by_sequence_number.rs
@@ -8,7 +8,7 @@ use serde_amqp::Value;
 use crate::{
     amqp::management_constants::properties::{LOCK_TOKEN, MESSAGE, MESSAGES},
     primitives::service_bus_received_message::{
-        ReceivedMessageLockToken, ServiceBusReceivedMessage,
+        ReceivedMessageLockToken, ReceivedMessage,
     },
 };
 
@@ -24,12 +24,12 @@ pub(crate) struct ReceiveBySequenceNumberResponse {
 impl ReceiveBySequenceNumberResponse {
     pub fn into_received_messages(
         self,
-    ) -> Result<Vec<ServiceBusReceivedMessage>, serde_amqp::Error> {
+    ) -> Result<Vec<ReceivedMessage>, serde_amqp::Error> {
         let mut received_messages = Vec::with_capacity(self.deferred_messages.len());
         for (lock_token, buf) in self.deferred_messages {
             let raw_amqp_message: Deserializable<Message<Body<Value>>> =
                 serde_amqp::from_slice(&buf)?;
-            let message = ServiceBusReceivedMessage {
+            let message = ReceivedMessage {
                 _is_settled: false,
                 raw_amqp_message: raw_amqp_message.0,
                 lock_token: ReceivedMessageLockToken::LockToken(lock_token),

--- a/src/amqp/amqp_response_message/receive_by_sequence_number.rs
+++ b/src/amqp/amqp_response_message/receive_by_sequence_number.rs
@@ -7,9 +7,7 @@ use serde_amqp::Value;
 
 use crate::{
     amqp::management_constants::properties::{LOCK_TOKEN, MESSAGE, MESSAGES},
-    primitives::service_bus_received_message::{
-        ReceivedMessageLockToken, ReceivedMessage,
-    },
+    primitives::service_bus_received_message::{ReceivedMessage, ReceivedMessageLockToken},
 };
 
 type DeferredMessage = OrderedMap<String, Value>;
@@ -22,9 +20,7 @@ pub(crate) struct ReceiveBySequenceNumberResponse {
 }
 
 impl ReceiveBySequenceNumberResponse {
-    pub fn into_received_messages(
-        self,
-    ) -> Result<Vec<ReceivedMessage>, serde_amqp::Error> {
+    pub fn into_received_messages(self) -> Result<Vec<ReceivedMessage>, serde_amqp::Error> {
         let mut received_messages = Vec::with_capacity(self.deferred_messages.len());
         for (lock_token, buf) in self.deferred_messages {
             let raw_amqp_message: Deserializable<Message<Body<Value>>> =

--- a/src/amqp/amqp_rule_manager.rs
+++ b/src/amqp/amqp_rule_manager.rs
@@ -10,7 +10,7 @@ use crate::{
     core::{RecoverableTransport, TransportRuleManager},
     primitives::{error::RetryError, service_bus_retry_policy::run_operation},
     sealed::Sealed,
-    ServiceBusRetryPolicy,
+    RetryPolicy,
 };
 
 use super::{
@@ -35,7 +35,7 @@ pub struct AmqpRuleManager {
     pub(crate) subscription_path: String,
 
     pub(crate) management_link: AmqpManagementLink,
-    pub(crate) retry_policy: Box<dyn ServiceBusRetryPolicy>,
+    pub(crate) retry_policy: Box<dyn RetryPolicy>,
 
     /// This is ONLY used for recovery
     pub(crate) connection_scope: Arc<Mutex<AmqpConnectionScope>>,

--- a/src/amqp/amqp_session_receiver.rs
+++ b/src/amqp/amqp_session_receiver.rs
@@ -9,10 +9,10 @@ use time::OffsetDateTime;
 
 use crate::{
     constants::DEFAULT_OFFSET_DATE_TIME, core::{RecoverableTransport, TransportReceiver, TransportSessionReceiver}, primitives::{
-        service_bus_peeked_message::ServiceBusPeekedMessage,
-        service_bus_received_message::ServiceBusReceivedMessage,
+        service_bus_peeked_message::PeekedMessage,
+        service_bus_received_message::ReceivedMessage,
         service_bus_retry_policy::run_operation,
-    }, sealed::Sealed, ServiceBusReceiveMode
+    }, sealed::Sealed, ReceiveMode
 };
 
 use super::{
@@ -132,14 +132,14 @@ impl TransportReceiver for AmqpSessionReceiver {
         self.inner.prefetch_count()
     }
 
-    fn receive_mode(&self) -> ServiceBusReceiveMode {
+    fn receive_mode(&self) -> ReceiveMode {
         self.inner.receive_mode()
     }
 
     async fn receive_messages(
         &mut self,
         max_messages: u32,
-    ) -> Result<Vec<ServiceBusReceivedMessage>, Self::ReceiveError> {
+    ) -> Result<Vec<ReceivedMessage>, Self::ReceiveError> {
         self.inner.receive_messages(max_messages).await
     }
 
@@ -147,7 +147,7 @@ impl TransportReceiver for AmqpSessionReceiver {
         &mut self,
         max_messages: u32,
         max_wait_time: Option<StdDuration>,
-    ) -> Result<Vec<ServiceBusReceivedMessage>, Self::ReceiveError> {
+    ) -> Result<Vec<ReceivedMessage>, Self::ReceiveError> {
         self.inner
             .receive_messages_with_max_wait_time(max_messages, max_wait_time)
             .await
@@ -159,7 +159,7 @@ impl TransportReceiver for AmqpSessionReceiver {
 
     async fn complete(
         &mut self,
-        message: &ServiceBusReceivedMessage,
+        message: &ReceivedMessage,
         session_id: Option<&str>,
     ) -> Result<(), Self::DispositionError> {
         self.inner.complete(message, session_id).await
@@ -167,7 +167,7 @@ impl TransportReceiver for AmqpSessionReceiver {
 
     async fn defer(
         &mut self,
-        message: &ServiceBusReceivedMessage,
+        message: &ReceivedMessage,
         properties_to_modify: Option<OrderedMap<String, Value>>,
         session_id: Option<&str>,
     ) -> Result<(), Self::DispositionError> {
@@ -180,7 +180,7 @@ impl TransportReceiver for AmqpSessionReceiver {
         &mut self,
         sequence_number: Option<i64>,
         message_count: i32,
-    ) -> Result<Vec<ServiceBusPeekedMessage>, Self::RequestResponseError> {
+    ) -> Result<Vec<PeekedMessage>, Self::RequestResponseError> {
         self.inner
             .peek_messages(sequence_number, message_count)
             .await
@@ -191,7 +191,7 @@ impl TransportReceiver for AmqpSessionReceiver {
         sequence_number: Option<i64>,
         message_count: i32,
         session_id: &str,
-    ) -> Result<Vec<ServiceBusPeekedMessage>, Self::RequestResponseError> {
+    ) -> Result<Vec<PeekedMessage>, Self::RequestResponseError> {
         self.inner
             .peek_session_messages(sequence_number, message_count, session_id)
             .await
@@ -199,7 +199,7 @@ impl TransportReceiver for AmqpSessionReceiver {
 
     async fn abandon(
         &mut self,
-        message: &ServiceBusReceivedMessage,
+        message: &ReceivedMessage,
         properties_to_modify: Option<OrderedMap<String, Value>>,
         session_id: Option<&str>,
     ) -> Result<(), Self::DispositionError> {
@@ -210,7 +210,7 @@ impl TransportReceiver for AmqpSessionReceiver {
 
     async fn dead_letter(
         &mut self,
-        message: &ServiceBusReceivedMessage,
+        message: &ReceivedMessage,
         dead_letter_reason: Option<String>,
         dead_letter_error_description: Option<String>,
         properties_to_modify: Option<OrderedMap<String, Value>>,
@@ -231,7 +231,7 @@ impl TransportReceiver for AmqpSessionReceiver {
         &mut self,
         sequence_numbers: impl Iterator<Item = i64> + Send,
         session_id: Option<&str>,
-    ) -> Result<Vec<ServiceBusReceivedMessage>, Self::RequestResponseError> {
+    ) -> Result<Vec<ReceivedMessage>, Self::RequestResponseError> {
         self.inner
             .receive_deferred_messages(sequence_numbers, session_id)
             .await

--- a/src/amqp/error.rs
+++ b/src/amqp/error.rs
@@ -21,12 +21,12 @@ use crate::{
         },
     },
     util::IntoAzureCoreError,
-    ServiceBusMessage,
+    Message,
 };
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::{ServiceBusPeekedMessage, ServiceBusReceivedMessage};
+use crate::{PeekedMessage, ReceivedMessage};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AmqpConnectionScopeError {
@@ -185,9 +185,9 @@ impl std::fmt::Display for MaxAllowedTtlExceededError {
 
 impl std::error::Error for MaxAllowedTtlExceededError {}
 
-/// The message carried in `ServiceBusReceivedMessage` or `ServiceBusPeekedMessage` is a raw AMQP
-/// message. Please use [`ServiceBusReceivedMessage::raw_amqp_message`] or
-/// [`ServiceBusPeekedMessage::raw_amqp_message`] to access the raw AMQP message body.
+/// The message carried in `ReceivedMessage` or `PeekedMessage` is a raw AMQP
+/// message. Please use [`ReceivedMessage::raw_amqp_message`] or
+/// [`PeekedMessage::raw_amqp_message`] to access the raw AMQP message body.
 #[derive(Debug, Clone)]
 pub struct RawAmqpMessageError {}
 
@@ -754,7 +754,7 @@ impl From<CbsAuthError> for azure_core::Error {
 pub enum TryAddMessageError {
     /// The message is too large to fit in a batch
     #[error("Message is too large to fit in a batch")]
-    BatchFull(ServiceBusMessage),
+    BatchFull(Message),
 
     /// The message cannot be serialized
     #[error("Cannot serialize message")]
@@ -762,7 +762,7 @@ pub enum TryAddMessageError {
         /// The error from the codec
         source: serde_amqp::Error,
         /// The message that could not be serialized
-        message: ServiceBusMessage,
+        message: Message,
     },
 }
 

--- a/src/client/service_bus_client.rs
+++ b/src/client/service_bus_client.rs
@@ -19,28 +19,28 @@ use crate::{
     entity_name_formatter::{self, format_entity_path},
     primitives::{
         service_bus_connection::{build_connection_resource, ServiceBusConnection},
-        service_bus_retry_options::ServiceBusRetryOptions,
+        service_bus_retry_options::RetryOptions,
         service_bus_retry_policy::ServiceBusRetryPolicyExt,
-        service_bus_transport_type::ServiceBusTransportType,
+        service_bus_transport_type::TransportType,
     },
     receiver::service_bus_session_receiver::{
-        ServiceBusSessionReceiver, ServiceBusSessionReceiverOptions,
+        SessionReceiver, SessionReceiverOptions,
     },
-    ServiceBusReceiver, ServiceBusReceiverOptions, ServiceBusRuleManager, ServiceBusSender,
-    ServiceBusSenderOptions,
+    Receiver, ReceiverOptions, RuleManager, Sender,
+    SenderOptions,
 };
 
 use super::error::AcceptNextSessionError;
 
-/// The set of options that can be specified when creating an [`ServiceBusClient`]
+/// The set of options that can be specified when creating an [`Client`]
 /// to configure its behavior.
 #[derive(Debug, Clone, Default)]
-pub struct ServiceBusClientOptions {
+pub struct ClientOptions {
     /// The type of protocol and transport that will be used for communicating with the Service
     /// Bus service.
-    pub transport_type: ServiceBusTransportType,
+    pub transport_type: TransportType,
 
-    /// A property used to set the [`ServiceBusClient`] ID to identify the client. This can be used
+    /// A property used to set the [`Client`] ID to identify the client. This can be used
     /// to correlate logs and exceptions. If `None` or empty, a random unique value will be
     /// used.
     pub identifier: Option<String>,
@@ -58,14 +58,14 @@ pub struct ServiceBusClientOptions {
     /// if so, the amount of time to wait between retry attempts.  These options also control the
     /// amount of time allowed for receiving messages and other interactions with the Service Bus
     /// service.
-    pub retry_options: ServiceBusRetryOptions,
+    pub retry_options: RetryOptions,
 
     /// Gets or sets a flag that indicates whether or not transactions may span multiple
     /// Service Bus entities.
     pub enable_cross_entity_transactions: bool,
 }
 
-/// Type state for [`ServiceBusClient`] indicating that the client is using a custom retry policy.
+/// Type state for [`Client`] indicating that the client is using a custom retry policy.
 #[derive(Debug)]
 pub struct WithCustomRetryPolicy<RP> {
     retry_policy: PhantomData<RP>,
@@ -75,27 +75,27 @@ impl<RP> WithCustomRetryPolicy<RP>
 where
     RP: ServiceBusRetryPolicyExt + Send + Sync + 'static,
 {
-    /// Creates a new instance of the [`ServiceBusClient`] class using the specified
-    /// connection string and [`ServiceBusClientOptions`].
+    /// Creates a new instance of the [`Client`] class using the specified
+    /// connection string and [`ClientOptions`].
     pub async fn new_from_connection_string<'a>(
         self,
         connection_string: impl Into<Cow<'a, str>>,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         let connection_string = connection_string.into();
         let identifier = options.identifier.clone();
         let connection = ServiceBusConnection::new(connection_string, options).await?;
         let identifier = identifier.unwrap_or_else(|| {
             diagnostics::utilities::generate_identifier(connection.fully_qualified_namespace())
         });
-        Ok(ServiceBusClient {
+        Ok(Client {
             identifier,
             connection,
         })
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using the specified
-    /// connection string and [`ServiceBusClientOptions`].
+    /// Creates a new instance of the [`Client`] class using the specified
+    /// connection string and [`ClientOptions`].
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_connection_string` instead"
@@ -103,18 +103,18 @@ where
     pub async fn create_client<'a>(
         self,
         connection_string: impl Into<Cow<'a, str>>,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         self.new_from_connection_string(connection_string, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a named key credential.
+    /// Creates a new instance of the [`Client`] class using a named key credential.
     pub async fn new_from_named_key_credential(
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: AzureNamedKeyCredential,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         let fully_qualified_namespace = fully_qualified_namespace.into();
         let signuture_resource = build_connection_resource(
             &options.transport_type,
@@ -126,7 +126,7 @@ where
         self.new_from_credential(fully_qualified_namespace, shared_access_credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a named key credential.
+    /// Creates a new instance of the [`Client`] class using a named key credential.
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_named_key_credential` instead"
@@ -135,23 +135,23 @@ where
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: AzureNamedKeyCredential,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         self.new_from_named_key_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a SAS token credential.
+    /// Creates a new instance of the [`Client`] class using a SAS token credential.
     pub async fn new_from_sas_credential(
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: AzureSasCredential,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         let shared_access_credential = SharedAccessCredential::try_from_sas_credential(credential)?;
         self.new_from_credential(fully_qualified_namespace, shared_access_credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a SAS token credential.
+    /// Creates a new instance of the [`Client`] class using a SAS token credential.
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_sas_credential` instead"
@@ -160,23 +160,23 @@ where
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: AzureSasCredential,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         self.new_from_sas_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a token credential.
+    /// Creates a new instance of the [`Client`] class using a token credential.
     pub async fn new_from_token_credential(
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: impl TokenCredential + 'static,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         let credential = ServiceBusTokenCredential::new(credential);
         self.new_from_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a token credential.
+    /// Creates a new instance of the [`Client`] class using a token credential.
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_token_credential` instead"
@@ -185,19 +185,19 @@ where
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: impl TokenCredential + 'static,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         self.new_from_token_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] using the specified
+    /// Creates a new instance of the [`Client`] using the specified
     /// namespace and credential
     pub async fn new_from_credential(
         self,
         fully_qualified_namespace: impl Into<String>,
         credential: impl Into<ServiceBusTokenCredential>,
-        options: ServiceBusClientOptions,
-    ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+        options: ClientOptions,
+    ) -> Result<Client<RP>, azure_core::Error> {
         let fully_qualified_namespace = fully_qualified_namespace.into();
         let identifier = options.identifier.clone().unwrap_or_else(|| {
             diagnostics::utilities::generate_identifier(&fully_qualified_namespace)
@@ -209,51 +209,51 @@ where
             options,
         )
         .await?;
-        Ok(ServiceBusClient {
+        Ok(Client {
             identifier,
             connection,
         })
     }
 }
 
-/// The [`ServiceBusClient`] is the top-level client through which all Service Bus entities can be
-/// interacted with. Any lower level types retrieved from here, such as [`ServiceBusSender`] and
-/// [`ServiceBusReceiver`] will share the same AMQP connection. Disposing the [`ServiceBusClient`]
+/// The [`Client`] is the top-level client through which all Service Bus entities can be
+/// interacted with. Any lower level types retrieved from here, such as [`Sender`] and
+/// [`Receiver`] will share the same AMQP connection. Disposing the [`Client`]
 /// will cause the AMQP connection to close.
 ///
 /// # WebAssembly support
 ///
-/// Creating a [`ServiceBusClient`] is supported for `wasm32-unknown-unknown` targets; however, the
+/// Creating a [`Client`] is supported for `wasm32-unknown-unknown` targets; however, the
 /// user must ensure that the client is created within the scope of a `tokio::task::LocalSet`.
 #[derive(Debug)]
-pub struct ServiceBusClient<RP> {
-    /// The name used to identify this [`ServiceBusClient`]
+pub struct Client<RP> {
+    /// The name used to identify this [`Client`]
     identifier: String,
 
     /// The connection that is used for the client.
     connection: ServiceBusConnection<AmqpClient<RP>>,
 }
 
-impl ServiceBusClient<BasicRetryPolicy> {
+impl Client<BasicRetryPolicy> {
     /// Use a custom retry policy for the client.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// use azservicebus::{
-    ///     ServiceBusClient, ServiceBusClientOptions, ServiceBusRetryPolicy,
+    ///     Client, ClientOptions, RetryPolicy,
     /// };
     ///
     /// struct MyRetryPolicy;
     ///
-    /// impl ServiceBusRetryPolicy for MyRetryPolicy {
+    /// impl RetryPolicy for MyRetryPolicy {
     ///     // ...
     /// }
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = ServiceBusClient::with_custom_retry_policy::<MyRetryPolicy>()
-    ///         .new_from_connection_string("<NAMESPACE-CONNECTION-STRING>", ServiceBusClientOptions::default())
+    ///     let mut client = Client::with_custom_retry_policy::<MyRetryPolicy>()
+    ///         .new_from_connection_string("<NAMESPACE-CONNECTION-STRING>", ClientOptions::default())
     ///         .await
     ///         .unwrap();
     /// }
@@ -264,21 +264,21 @@ impl ServiceBusClient<BasicRetryPolicy> {
         }
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using the specified connection
-    /// string and [`ServiceBusClientOptions`].
+    /// Creates a new instance of the [`Client`] class using the specified connection
+    /// string and [`ClientOptions`].
     ///
     /// # Example
     ///
     /// ```rust,no_run
     /// use azservicebus::{
-    ///     ServiceBusClient, ServiceBusClientOptions,
+    ///     Client, ClientOptions,
     /// };
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = ServiceBusClient::new_from_connection_string(
+    ///     let mut client = Client::new_from_connection_string(
     ///             "<NAMESPACE-CONNECTION-STRING>",
-    ///             ServiceBusClientOptions::default()
+    ///             ClientOptions::default()
     ///         )
     ///         .await
     ///         .unwrap();
@@ -287,40 +287,40 @@ impl ServiceBusClient<BasicRetryPolicy> {
     /// ```
     pub async fn new_from_connection_string<'a>(
         connection_string: impl Into<Cow<'a, str>>,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::with_custom_retry_policy()
             .new_from_connection_string(connection_string, options)
             .await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using the specified
-    /// connection string and [`ServiceBusClientOptions`].
+    /// Creates a new instance of the [`Client`] class using the specified
+    /// connection string and [`ClientOptions`].
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_connection_string` instead"
     )]
     pub async fn new<'a>(
         connection_string: impl Into<Cow<'a, str>>,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::with_custom_retry_policy()
             .new_from_connection_string(connection_string, options)
             .await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a named key credential.
+    /// Creates a new instance of the [`Client`] class using a named key credential.
     pub async fn new_from_named_key_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: AzureNamedKeyCredential,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::with_custom_retry_policy()
             .new_from_named_key_credential(fully_qualified_namespace, credential, options)
             .await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a named key credential.
+    /// Creates a new instance of the [`Client`] class using a named key credential.
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_named_key_credential` instead"
@@ -328,23 +328,23 @@ impl ServiceBusClient<BasicRetryPolicy> {
     pub async fn new_with_named_key_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: AzureNamedKeyCredential,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::new_from_named_key_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a SAS token credential.
+    /// Creates a new instance of the [`Client`] class using a SAS token credential.
     pub async fn new_from_sas_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: AzureSasCredential,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::with_custom_retry_policy()
             .new_from_sas_credential(fully_qualified_namespace, credential, options)
             .await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a SAS token credential.
+    /// Creates a new instance of the [`Client`] class using a SAS token credential.
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_sas_credential` instead"
@@ -352,23 +352,23 @@ impl ServiceBusClient<BasicRetryPolicy> {
     pub async fn new_with_sas_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: AzureSasCredential,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::new_from_sas_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a token credential.
+    /// Creates a new instance of the [`Client`] class using a token credential.
     pub async fn new_from_token_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: impl TokenCredential + 'static,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::with_custom_retry_policy()
             .new_from_token_credential(fully_qualified_namespace, credential, options)
             .await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] class using a token credential.
+    /// Creates a new instance of the [`Client`] class using a token credential.
     #[deprecated(
         since = "0.14.0",
         note = "Please use `new_from_token_credential` instead"
@@ -376,17 +376,17 @@ impl ServiceBusClient<BasicRetryPolicy> {
     pub async fn new_with_token_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: impl TokenCredential + 'static,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::new_from_token_credential(fully_qualified_namespace, credential, options).await
     }
 
-    /// Creates a new instance of the [`ServiceBusClient`] using the specified
+    /// Creates a new instance of the [`Client`] using the specified
     /// namespace and credential.
     pub async fn new_from_credential(
         fully_qualified_namespace: impl Into<String>,
         credential: impl Into<ServiceBusTokenCredential>,
-        options: ServiceBusClientOptions,
+        options: ClientOptions,
     ) -> Result<Self, azure_core::Error> {
         Self::with_custom_retry_policy()
             .new_from_credential(fully_qualified_namespace, credential, options)
@@ -394,7 +394,7 @@ impl ServiceBusClient<BasicRetryPolicy> {
     }
 }
 
-impl<RP> ServiceBusClient<RP>
+impl<RP> Client<RP>
 where
     RP: ServiceBusRetryPolicyExt + 'static,
 {
@@ -404,12 +404,12 @@ where
         self.connection.fully_qualified_namespace()
     }
 
-    /// The name used to identify this [`ServiceBusClient`].
+    /// The name used to identify this [`Client`].
     pub fn identifier(&self) -> &str {
         &self.identifier
     }
 
-    /// Indicates whether or not this [`ServiceBusClient`] has been closed.
+    /// Indicates whether or not this [`Client`] has been closed.
     pub fn is_closed(&self) -> bool {
         self.connection.is_closed()
     }
@@ -419,11 +419,11 @@ where
 /*                                   Dispose                                  */
 /* -------------------------------------------------------------------------- */
 
-impl<RP> ServiceBusClient<RP>
+impl<RP> Client<RP>
 where
     RP: ServiceBusRetryPolicyExt + 'static,
 {
-    /// Performs the task needed to clean up resources used by the [`ServiceBusClient`],
+    /// Performs the task needed to clean up resources used by the [`Client`],
     /// including ensuring that the client itself has been closed.
     pub async fn dispose(self) -> Result<(), azure_core::Error> {
         self.connection.dispose().await?;
@@ -435,11 +435,11 @@ where
 /*                                Create Sender                               */
 /* -------------------------------------------------------------------------- */
 
-impl<RP> ServiceBusClient<RP>
+impl<RP> Client<RP>
 where
     RP: ServiceBusRetryPolicyExt + 'static,
 {
-    /// Creates a new [`ServiceBusSender`] which can be used to send messages to a specific queue or
+    /// Creates a new [`Sender`] which can be used to send messages to a specific queue or
     /// topic.
     ///
     /// # WebAssembly support
@@ -449,8 +449,8 @@ where
     pub async fn create_sender(
         &mut self,
         queue_or_topic_name: impl Into<String>,
-        options: ServiceBusSenderOptions,
-    ) -> Result<ServiceBusSender, azure_core::Error> {
+        options: SenderOptions,
+    ) -> Result<Sender, azure_core::Error> {
         let entity_path = queue_or_topic_name.into();
         let identifier = options
             .identifier
@@ -462,7 +462,7 @@ where
             .create_transport_sender(entity_path, identifier, retry_options)
             .await?;
 
-        Ok(ServiceBusSender { inner })
+        Ok(Sender { inner })
     }
 }
 
@@ -470,16 +470,16 @@ where
 /*                               Create Receiver                              */
 /* -------------------------------------------------------------------------- */
 
-impl<RP> ServiceBusClient<RP>
+impl<RP> Client<RP>
 where
     RP: ServiceBusRetryPolicyExt + 'static,
 {
     /// The transport type used by the client.
-    pub fn transport_type(&self) -> ServiceBusTransportType {
+    pub fn transport_type(&self) -> TransportType {
         self.connection.transport_type()
     }
 
-    /// Creates a new [`ServiceBusReceiver`] which can be used to receive messages from a specific
+    /// Creates a new [`Receiver`] which can be used to receive messages from a specific
     /// queue.
     ///
     /// # WebAssembly support
@@ -489,14 +489,14 @@ where
     pub async fn create_receiver_for_queue(
         &mut self,
         queue_name: impl Into<String>,
-        options: ServiceBusReceiverOptions,
-    ) -> Result<ServiceBusReceiver, azure_core::Error> {
+        options: ReceiverOptions,
+    ) -> Result<Receiver, azure_core::Error> {
         let entity_path = queue_name.into();
         self.create_receiver(entity_path, options).await
             .map_err(Into::into)
     }
 
-    /// Creates a new [`ServiceBusReceiver`] which can be used to receive messages from a specific
+    /// Creates a new [`Receiver`] which can be used to receive messages from a specific
     /// subscription.
     ///
     /// # WebAssembly support
@@ -507,8 +507,8 @@ where
         &mut self,
         topic_name: impl AsRef<str>,
         subscription_name: impl AsRef<str>,
-        options: ServiceBusReceiverOptions,
-    ) -> Result<ServiceBusReceiver, azure_core::Error> {
+        options: ReceiverOptions,
+    ) -> Result<Receiver, azure_core::Error> {
         let entity_path = entity_name_formatter::format_subscription_path(
             topic_name.as_ref(),
             subscription_name.as_ref(),
@@ -521,8 +521,8 @@ where
     async fn create_receiver(
         &mut self,
         entity_path: String,
-        options: ServiceBusReceiverOptions,
-    ) -> Result<ServiceBusReceiver, OpenReceiverError> {
+        options: ReceiverOptions,
+    ) -> Result<Receiver, OpenReceiverError> {
         let identifier = options
             .identifier
             .filter(|id| !id.is_empty())
@@ -542,15 +542,15 @@ where
                 prefetch_count,
             )
             .await?;
-        Ok(ServiceBusReceiver { inner })
+        Ok(Receiver { inner })
     }
 
-    /// Creates a [`ServiceBusSessionReceiver`] instance that can be used for receiving
+    /// Creates a [`SessionReceiver`] instance that can be used for receiving
     /// and settling messages from a session-enabled queue by accepting the next unlocked session that contains Active messages. If there
-    /// are no unlocked sessions with Active messages, then the call will timeout after the configured [`ServiceBusRetryOptions::try_timeout`] value and returns
+    /// are no unlocked sessions with Active messages, then the call will timeout after the configured [`RetryOptions::try_timeout`] value and returns
     /// an error.
     ///
-    /// [`ServiceBusReceiverOptions::receive_mode`] can be specified to configure how messages are received.
+    /// [`ReceiverOptions::receive_mode`] can be specified to configure how messages are received.
     ///
     /// # WebAssembly support
     ///
@@ -560,19 +560,19 @@ where
         &mut self,
         queue_name: impl Into<String>,
         session_id: impl Into<String>,
-        options: ServiceBusSessionReceiverOptions,
-    ) -> Result<ServiceBusSessionReceiver, azure_core::Error> {
+        options: SessionReceiverOptions,
+    ) -> Result<SessionReceiver, azure_core::Error> {
         let entity_path = queue_name.into();
         let session_id = session_id.into();
         self.accept_session(entity_path, session_id, options).await.map_err(Into::into)
     }
 
-    /// Creates a [`ServiceBusSessionReceiver`] instance that can be used for receiving
+    /// Creates a [`SessionReceiver`] instance that can be used for receiving
     /// and settling messages from a session-enabled subscription by accepting the next unlocked session that contains Active messages. If there
-    /// are no unlocked sessions with Active messages, then the call will timeout after the configured [`ServiceBusRetryOptions::try_timeout`] value and returns
+    /// are no unlocked sessions with Active messages, then the call will timeout after the configured [`RetryOptions::try_timeout`] value and returns
     /// an error.
     ///
-    /// [`ServiceBusReceiverOptions::receive_mode`] can be specified to configure how messages are received.
+    /// [`ReceiverOptions::receive_mode`] can be specified to configure how messages are received.
     ///
     /// # WebAssembly support
     ///
@@ -583,8 +583,8 @@ where
         topic_name: impl AsRef<str>,
         subscription_name: impl AsRef<str>,
         session_id: impl Into<String>,
-        options: ServiceBusSessionReceiverOptions,
-    ) -> Result<ServiceBusSessionReceiver, azure_core::Error> {
+        options: SessionReceiverOptions,
+    ) -> Result<SessionReceiver, azure_core::Error> {
         let entity_path = entity_name_formatter::format_subscription_path(
             topic_name.as_ref(),
             subscription_name.as_ref(),
@@ -597,8 +597,8 @@ where
         &mut self,
         entity_path: String,
         session_id: String,
-        options: ServiceBusSessionReceiverOptions,
-    ) -> Result<ServiceBusSessionReceiver, OpenReceiverError> {
+        options: SessionReceiverOptions,
+    ) -> Result<SessionReceiver, OpenReceiverError> {
         let identifier = options
             .identifier
             .unwrap_or_else(|| diagnostics::utilities::generate_identifier(&entity_path));
@@ -618,15 +618,15 @@ where
             )
             .await?;
 
-        Ok(ServiceBusSessionReceiver { inner, session_id })
+        Ok(SessionReceiver { inner, session_id })
     }
 }
 
-impl<RP> ServiceBusClient<RP>
+impl<RP> Client<RP>
 where
     RP: ServiceBusRetryPolicyExt + 'static,
 {
-    /// Creates a [`ServiceBusSessionReceiver`] instance that can be used for receiving and settling
+    /// Creates a [`SessionReceiver`] instance that can be used for receiving and settling
     /// messages from a session-enabled queue by accepting the next unlocked session that contains
     /// Active messages.
     ///
@@ -637,13 +637,13 @@ where
     pub async fn accept_next_session_for_queue(
         &mut self,
         queue_name: impl Into<String>,
-        options: ServiceBusSessionReceiverOptions,
-    ) -> Result<ServiceBusSessionReceiver, azure_core::Error> {
+        options: SessionReceiverOptions,
+    ) -> Result<SessionReceiver, azure_core::Error> {
         let entity_path = queue_name.into();
         self.accept_next_session(entity_path, options).await.map_err(Into::into)
     }
 
-    /// Creates a [`ServiceBusSessionReceiver`] instance that can be used for receiving and settling
+    /// Creates a [`SessionReceiver`] instance that can be used for receiving and settling
     /// messages from a session-enabled subscription by accepting the next unlocked session that
     /// contains Active messages.
     ///
@@ -655,8 +655,8 @@ where
         &mut self,
         topic_name: impl AsRef<str>,
         subscription_name: impl AsRef<str>,
-        options: ServiceBusSessionReceiverOptions,
-    ) -> Result<ServiceBusSessionReceiver, azure_core::Error> {
+        options: SessionReceiverOptions,
+    ) -> Result<SessionReceiver, azure_core::Error> {
         let entity_path = entity_name_formatter::format_subscription_path(
             topic_name.as_ref(),
             subscription_name.as_ref(),
@@ -667,8 +667,8 @@ where
     async fn accept_next_session(
         &mut self,
         entity_path: String,
-        options: ServiceBusSessionReceiverOptions,
-    ) -> Result<ServiceBusSessionReceiver, AcceptNextSessionError> {
+        options: SessionReceiverOptions,
+    ) -> Result<SessionReceiver, AcceptNextSessionError> {
         let identifier = options
             .identifier
             .unwrap_or_else(|| diagnostics::utilities::generate_identifier(&entity_path));
@@ -693,7 +693,7 @@ where
             .ok_or(AcceptNextSessionError::SessionIdNotSet)?
             .to_string();
 
-        Ok(ServiceBusSessionReceiver { inner, session_id })
+        Ok(SessionReceiver { inner, session_id })
     }
 }
 
@@ -701,11 +701,11 @@ where
 /*                             Create RuleManager                             */
 /* -------------------------------------------------------------------------- */
 
-impl<RP> ServiceBusClient<RP>
+impl<RP> Client<RP>
 where
     RP: ServiceBusRetryPolicyExt + 'static,
 {
-    /// Creates a [`ServiceBusRuleManager`] instance that can be used for managing rules on a
+    /// Creates a [`RuleManager`] instance that can be used for managing rules on a
     /// subscription.
     ///
     /// # WebAssembly support
@@ -716,7 +716,7 @@ where
         &mut self,
         topic_name: impl AsRef<str>,
         subscription_name: impl AsRef<str>,
-    ) -> Result<ServiceBusRuleManager, azure_core::Error> {
+    ) -> Result<RuleManager, azure_core::Error> {
         let subscription_path = entity_name_formatter::format_subscription_path(
             topic_name.as_ref(),
             subscription_name.as_ref(),
@@ -729,6 +729,6 @@ where
             .create_transport_rule_manager(subscription_path, identifier, retry_options)
             .await?;
 
-        Ok(ServiceBusRuleManager { inner })
+        Ok(RuleManager { inner })
     }
 }

--- a/src/core/basic_retry_policy.rs
+++ b/src/core/basic_retry_policy.rs
@@ -2,10 +2,10 @@ use rand::Rng;
 use std::{fmt::Display, time::Duration};
 
 use crate::primitives::{
-    service_bus_retry_mode::ServiceBusRetryMode,
-    service_bus_retry_options::ServiceBusRetryOptions,
+    service_bus_retry_mode::RetryMode,
+    service_bus_retry_options::RetryOptions,
     service_bus_retry_policy::{
-        ServiceBusRetryPolicy, ServiceBusRetryPolicyError, ServiceBusRetryPolicyState,
+        RetryPolicy, ServiceBusRetryPolicyError, ServiceBusRetryPolicyState,
     },
 };
 
@@ -54,10 +54,10 @@ impl ServiceBusRetryPolicyState for BasicRetryPolicyState {
 }
 
 /// The default retry policy for the Service Bus client library, respecting the
-/// configuration specified as a set of [`ServiceBusRetryOptions`].
+/// configuration specified as a set of [`RetryOptions`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BasicRetryPolicy {
-    options: ServiceBusRetryOptions,
+    options: RetryOptions,
     state: BasicRetryPolicyState,
 }
 
@@ -67,8 +67,8 @@ impl Display for BasicRetryPolicy {
     }
 }
 
-impl From<ServiceBusRetryOptions> for BasicRetryPolicy {
-    fn from(options: ServiceBusRetryOptions) -> Self {
+impl From<RetryOptions> for BasicRetryPolicy {
+    fn from(options: RetryOptions) -> Self {
         Self {
             options,
             state: BasicRetryPolicyState::default(),
@@ -76,8 +76,8 @@ impl From<ServiceBusRetryOptions> for BasicRetryPolicy {
     }
 }
 
-impl ServiceBusRetryPolicy for BasicRetryPolicy {
-    fn options(&self) -> &ServiceBusRetryOptions {
+impl RetryPolicy for BasicRetryPolicy {
+    fn options(&self) -> &RetryOptions {
         &self.options
     }
 
@@ -109,12 +109,12 @@ impl ServiceBusRetryPolicy for BasicRetryPolicy {
         let base_jitter_seconds = self.options.delay.as_secs_f64() * JITTER_FACTOR;
         let mut rng = rand::thread_rng();
         let retry_delay = match self.options.mode {
-            ServiceBusRetryMode::Fixed => calculate_fixed_delay(
+            RetryMode::Fixed => calculate_fixed_delay(
                 self.options.delay.as_secs_f64(),
                 base_jitter_seconds,
                 &mut rng,
             ),
-            ServiceBusRetryMode::Exponential => calculate_exponential_delay(
+            RetryMode::Exponential => calculate_exponential_delay(
                 attempt_count,
                 self.options.delay.as_secs_f64(),
                 base_jitter_seconds,

--- a/src/core/transport_client.rs
+++ b/src/core/transport_client.rs
@@ -5,8 +5,7 @@ use azure_core::Url;
 use crate::{
     authorization::service_bus_token_credential::ServiceBusTokenCredential,
     primitives::{
-        service_bus_retry_options::RetryOptions,
-        service_bus_transport_type::TransportType,
+        service_bus_retry_options::RetryOptions, service_bus_transport_type::TransportType,
     },
     receiver::service_bus_receive_mode::ReceiveMode,
     sealed::Sealed,

--- a/src/core/transport_client.rs
+++ b/src/core/transport_client.rs
@@ -5,10 +5,10 @@ use azure_core::Url;
 use crate::{
     authorization::service_bus_token_credential::ServiceBusTokenCredential,
     primitives::{
-        service_bus_retry_options::ServiceBusRetryOptions,
-        service_bus_transport_type::ServiceBusTransportType,
+        service_bus_retry_options::RetryOptions,
+        service_bus_transport_type::TransportType,
     },
-    receiver::service_bus_receive_mode::ServiceBusReceiveMode,
+    receiver::service_bus_receive_mode::ReceiveMode,
     sealed::Sealed,
 };
 
@@ -19,7 +19,7 @@ use super::{
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::ServiceBusMessage;
+use crate::Message;
 
 /// Provides an abstraction for generalizing an Service Bus entity client so that a dedicated
 /// instance may provide operations for a specific transport.
@@ -55,13 +55,13 @@ pub(crate) trait TransportClient: Sized + Sealed {
     async fn create_transport_client(
         host: &str,
         credential: ServiceBusTokenCredential,
-        transport_type: ServiceBusTransportType,
+        transport_type: TransportType,
         custom_endpoint: Option<Url>,
         retry_timeout: StdDuration,
     ) -> Result<Self, Self::CreateClientError>;
 
     /// Get the transport type
-    fn transport_type(&self) -> ServiceBusTransportType;
+    fn transport_type(&self) -> TransportType;
 
     /// Indicates whether or not this client has been closed.
     ///
@@ -69,12 +69,12 @@ pub(crate) trait TransportClient: Sized + Sealed {
     fn is_closed(&self) -> bool;
 
     /// Creates a sender strongly aligned with the active protocol and transport,
-    /// responsible for sending [`ServiceBusMessage`] to the entity.
+    /// responsible for sending [`Message`] to the entity.
     async fn create_sender(
         &mut self,
         entity_path: String,
         identifier: String,
-        retry_policy: ServiceBusRetryOptions,
+        retry_policy: RetryOptions,
     ) -> Result<Self::Sender, Self::CreateSenderError>;
 
     /// Creates a receiver
@@ -82,8 +82,8 @@ pub(crate) trait TransportClient: Sized + Sealed {
         &mut self,
         entity_path: String,
         identifier: String,
-        retry_options: ServiceBusRetryOptions,
-        receive_mode: ServiceBusReceiveMode,
+        retry_options: RetryOptions,
+        receive_mode: ReceiveMode,
         prefetch_count: u32,
     ) -> Result<Self::Receiver, Self::CreateReceiverError>;
 
@@ -92,8 +92,8 @@ pub(crate) trait TransportClient: Sized + Sealed {
         &mut self,
         entity_path: String,
         identifier: String,
-        retry_options: ServiceBusRetryOptions,
-        receive_mode: ServiceBusReceiveMode,
+        retry_options: RetryOptions,
+        receive_mode: ReceiveMode,
         session_id: Option<String>,
         prefetch_count: u32,
     ) -> Result<Self::SessionReceiver, Self::CreateReceiverError>;
@@ -111,7 +111,7 @@ pub(crate) trait TransportClient: Sized + Sealed {
         &mut self,
         subscription_path: String,
         identifier: String,
-        retry_policy: ServiceBusRetryOptions,
+        retry_policy: RetryOptions,
     ) -> Result<Self::RuleManager, Self::CreateRuleManagerError>;
 
     /// Closes the connection to the transport client instance.

--- a/src/core/transport_message_batch.rs
+++ b/src/core/transport_message_batch.rs
@@ -1,4 +1,4 @@
-use crate::{sealed::Sealed, ServiceBusMessage};
+use crate::{sealed::Sealed, Message};
 
 /// Trait for a message batch.
 pub(crate) trait TransportMessageBatch: Sealed {
@@ -22,8 +22,8 @@ pub(crate) trait TransportMessageBatch: Sealed {
     /// Returns true if the batch is empty.
     fn is_empty(&self) -> bool;
 
-    /// Attempts to add a [`ServiceBusMessage`] to the batch.
-    fn try_add_message(&mut self, message: ServiceBusMessage) -> Result<(), Self::TryAddError>;
+    /// Attempts to add a [`Message`] to the batch.
+    fn try_add_message(&mut self, message: Message) -> Result<(), Self::TryAddError>;
 
     /// Iterate over the messages in the batch.
     fn iter(&self) -> Self::Iter<'_>;

--- a/src/core/transport_receiver.rs
+++ b/src/core/transport_receiver.rs
@@ -5,8 +5,7 @@ use time::OffsetDateTime;
 
 use crate::{
     primitives::{
-        service_bus_peeked_message::PeekedMessage,
-        service_bus_received_message::ReceivedMessage,
+        service_bus_peeked_message::PeekedMessage, service_bus_received_message::ReceivedMessage,
     },
     sealed::Sealed,
     ReceiveMode,

--- a/src/core/transport_sender.rs
+++ b/src/core/transport_sender.rs
@@ -1,14 +1,14 @@
-use crate::{sealed::Sealed, CreateMessageBatchOptions, ServiceBusMessage};
+use crate::{sealed::Sealed, CreateMessageBatchOptions, Message};
 
 use super::TransportMessageBatch;
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::ServiceBusSender;
+use crate::Sender;
 
 /// Provides an abstraction for generalizing an Service Bus entity Producer so that a dedicated
 /// instance may provide operations for a specific transport, such as AMQP or JMS.  It is intended
-/// that the public [`ServiceBusSender`] employ a transport producer via containment and delegate
+/// that the public [`Sender`] employ a transport producer via containment and delegate
 /// operations to it rather than understanding protocol-specific details for different transports.
 pub(crate) trait TransportSender: Sealed {
     /// Error with sending a message
@@ -32,7 +32,7 @@ pub(crate) trait TransportSender: Sealed {
     /// Get the identifier
     fn identifier(&self) -> &str;
 
-    /// Creates a size-constraint batch to which [`ServiceBusMessage`] may be added using
+    /// Creates a size-constraint batch to which [`Message`] may be added using
     /// a try-based pattern.  If a message would exceed the maximum allowable size of the batch, the
     /// batch will not allow adding the message and signal that scenario using its return value.
     ///
@@ -49,7 +49,7 @@ pub(crate) trait TransportSender: Sealed {
     /// in a batch, use [`TransportSender::send_batch`] instead.
     async fn send(
         &mut self,
-        messages: impl ExactSizeIterator<Item = ServiceBusMessage> + Send,
+        messages: impl ExactSizeIterator<Item = Message> + Send,
     ) -> Result<(), Self::SendError>;
 
     /// Sends a [`Self::MessageBatch`] to the associated Queue/Topic.
@@ -61,7 +61,7 @@ pub(crate) trait TransportSender: Sealed {
     /// Schedules a list of messages to appear on Service Bus at a later time.
     async fn schedule_messages(
         &mut self,
-        messages: impl Iterator<Item = ServiceBusMessage> + Send,
+        messages: impl Iterator<Item = Message> + Send,
     ) -> Result<Vec<i64>, Self::ScheduleError>;
 
     /// Cancels one or more messages that were scheduled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,16 +42,16 @@
 //!     // Replace "<NAMESPACE-CONNECTION-STRING>" with your connection string,
 //!     // which can be found in the Azure portal and should look like
 //!     // "Endpoint=sb://<NAMESPACE>.servicebus.windows.net/;SharedAccessKeyName=<KEY_NAME>;SharedAccessKey=<KEY_VALUE>"
-//!     let mut client = ServiceBusClient::new_from_connection_string(
+//!     let mut client = Client::new_from_connection_string(
 //!         "<NAMESPACE-CONNECTION-STRING>",
-//!         ServiceBusClientOptions::default()
+//!         ClientOptions::default()
 //!     )
 //!     .await?;
 //!
 //!     // Replace "<QUEUE-NAME>" with the name of your queue
 //!     let mut sender = client.create_sender(
 //!         "<QUEUE-NAME>",
-//!         ServiceBusSenderOptions::default()
+//!         SenderOptions::default()
 //!     )
 //!     .await?;
 //!
@@ -60,7 +60,7 @@
 //!
 //!     for i in 0..3 {
 //!         // Create a message
-//!         let message = ServiceBusMessage::new(format!("Message {}", i));
+//!         let message = Message::new(format!("Message {}", i));
 //!         // Try to add the message to the batch
 //!         if let Err(e) = message_batch.try_add_message(message) {
 //!             // If the batch is full, an error will be returned
@@ -92,16 +92,16 @@
 //!     // Replace "<NAMESPACE-CONNECTION-STRING>" with your connection string,
 //!     // which can be found in the Azure portal and should look like
 //!     // "Endpoint=sb://<NAMESPACE>.servicebus.windows.net/;SharedAccessKeyName=<KEY_NAME>;SharedAccessKey=<KEY_VALUE>"
-//!     let mut client = ServiceBusClient::new_from_connection_string(
+//!     let mut client = Client::new_from_connection_string(
 //!         "<NAMESPACE-CONNECTION-STRING>",
-//!         ServiceBusClientOptions::default()
+//!         ClientOptions::default()
 //!     )
 //!     .await?;
 //!
 //!     // Replace "<QUEUE-NAME>" with the name of your queue
 //!     let mut receiver = client.create_receiver_for_queue(
 //!         "<QUEUE-NAME>",
-//!         ServiceBusReceiverOptions::default()
+//!         ReceiverOptions::default()
 //!     )
 //!     .await?;
 //!
@@ -224,27 +224,27 @@ pub mod prelude {
     //! Re-exports
 
     cfg_either_rustls_or_native_tls! {
-        pub use crate::client::service_bus_client::{ServiceBusClient, ServiceBusClientOptions};
-        pub use crate::rule_manager::service_bus_rule_manager::ServiceBusRuleManager;
-        pub use crate::sender::service_bus_sender::{ServiceBusSender, ServiceBusSenderOptions};
-        pub use crate::receiver::service_bus_receiver::{ServiceBusReceiver, ServiceBusReceiverOptions};
-        pub use crate::receiver::service_bus_session_receiver::{ServiceBusSessionReceiver, ServiceBusSessionReceiverOptions};
+        pub use crate::client::service_bus_client::{Client, ClientOptions};
+        pub use crate::rule_manager::service_bus_rule_manager::{RuleManager};
+        pub use crate::sender::service_bus_sender::{Sender, SenderOptions};
+        pub use crate::receiver::service_bus_receiver::{Receiver, ReceiverOptions};
+        pub use crate::receiver::service_bus_session_receiver::{SessionReceiver, SessionReceiverOptions};
     }
 
     pub use crate::primitives::{
-        service_bus_connection_string_properties::ServiceBusConnectionStringProperties,
-        service_bus_message::ServiceBusMessage, service_bus_message_state::ServiceBusMessageState,
-        service_bus_peeked_message::ServiceBusPeekedMessage,
-        service_bus_received_message::ServiceBusReceivedMessage,
-        service_bus_retry_mode::ServiceBusRetryMode,
-        service_bus_retry_options::ServiceBusRetryOptions,
-        service_bus_retry_policy::ServiceBusRetryPolicy,
-        service_bus_transport_type::ServiceBusTransportType, sub_queue::SubQueue,
+        service_bus_connection_string_properties::ConnectionStringProperties,
+        service_bus_message::Message, service_bus_message_state::MessageState,
+        service_bus_peeked_message::PeekedMessage,
+        service_bus_received_message::ReceivedMessage,
+        service_bus_retry_mode::RetryMode,
+        service_bus_retry_options::RetryOptions,
+        service_bus_retry_policy::RetryPolicy,
+        service_bus_transport_type::TransportType, sub_queue::SubQueue,
     };
-    pub use crate::receiver::service_bus_receive_mode::ServiceBusReceiveMode;
+    pub use crate::receiver::service_bus_receive_mode::ReceiveMode;
     pub use crate::sender::{
         service_bus_message_batch::CreateMessageBatchOptions,
-        service_bus_message_batch::ServiceBusMessageBatch,
+        service_bus_message_batch::MessageBatch,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,12 +234,10 @@ pub mod prelude {
     pub use crate::primitives::{
         service_bus_connection_string_properties::ConnectionStringProperties,
         service_bus_message::Message, service_bus_message_state::MessageState,
-        service_bus_peeked_message::PeekedMessage,
-        service_bus_received_message::ReceivedMessage,
-        service_bus_retry_mode::RetryMode,
-        service_bus_retry_options::RetryOptions,
-        service_bus_retry_policy::RetryPolicy,
-        service_bus_transport_type::TransportType, sub_queue::SubQueue,
+        service_bus_peeked_message::PeekedMessage, service_bus_received_message::ReceivedMessage,
+        service_bus_retry_mode::RetryMode, service_bus_retry_options::RetryOptions,
+        service_bus_retry_policy::RetryPolicy, service_bus_transport_type::TransportType,
+        sub_queue::SubQueue,
     };
     pub use crate::receiver::service_bus_receive_mode::ReceiveMode;
     pub use crate::sender::{

--- a/src/primitives/service_bus_connection_string_properties.rs
+++ b/src/primitives/service_bus_connection_string_properties.rs
@@ -469,8 +469,8 @@ mod tests {
         ]
     }
 
-    fn to_connection_string_validates_properties_cases(
-    ) -> Vec<ConnectionStringProperties<'static>> {
+    fn to_connection_string_validates_properties_cases() -> Vec<ConnectionStringProperties<'static>>
+    {
         let mut cases = Vec::new();
         // "missing endpoint"
         let case = ConnectionStringProperties {

--- a/src/primitives/service_bus_connection_string_properties.rs
+++ b/src/primitives/service_bus_connection_string_properties.rs
@@ -38,7 +38,7 @@ pub enum ToConnectionStringError {
 
 /// The set of properties that comprise a Service Bus connection string.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct ServiceBusConnectionStringProperties<'a> {
+pub struct ConnectionStringProperties<'a> {
     pub(crate) endpoint: Option<url::Url>,
     pub(crate) entity_path: Option<&'a str>,
     pub(crate) shared_access_key_name: Option<&'a str>,
@@ -46,7 +46,7 @@ pub struct ServiceBusConnectionStringProperties<'a> {
     pub(crate) shared_access_signature: Option<&'a str>,
 }
 
-impl<'a> ServiceBusConnectionStringProperties<'a> {
+impl<'a> ConnectionStringProperties<'a> {
     /// The character used to separate a token and its value in the connection string.
     const TOKEN_VALUE_SEPARATOR: char = '=';
 
@@ -107,7 +107,7 @@ impl<'a> ServiceBusConnectionStringProperties<'a> {
     }
 
     /// Creates an Service Bus connection string based on this set of
-    /// [`ServiceBusConnectionStringProperties`].
+    /// [`ConnectionStringProperties`].
     pub fn to_connection_string(&self) -> Result<String, ToConnectionStringError> {
         let mut s = String::new();
 
@@ -242,7 +242,7 @@ impl<'a> ServiceBusConnectionStringProperties<'a> {
 mod tests {
     use crate::primitives::service_bus_connection_string_properties::FormatError;
 
-    use super::ServiceBusConnectionStringProperties;
+    use super::ConnectionStringProperties;
 
     const ENDPOINT: &str = "test.endpoint.com";
     const EVENT_HUB: &str = "some-path";
@@ -260,7 +260,7 @@ mod tests {
 
     macro_rules! assert_parsed_and_expected {
         ($connection_string:ident, $expected:ident) => {
-            let parsed = ServiceBusConnectionStringProperties::parse(&$connection_string).unwrap();
+            let parsed = ConnectionStringProperties::parse(&$connection_string).unwrap();
 
             assert_eq!(
                 parsed.endpoint().and_then(|url| url.host_str()),
@@ -470,10 +470,10 @@ mod tests {
     }
 
     fn to_connection_string_validates_properties_cases(
-    ) -> Vec<ServiceBusConnectionStringProperties<'static>> {
+    ) -> Vec<ConnectionStringProperties<'static>> {
         let mut cases = Vec::new();
         // "missing endpoint"
-        let case = ServiceBusConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: None,
             entity_path: Some("fake"),
             shared_access_signature: Some("fake"),
@@ -483,7 +483,7 @@ mod tests {
         cases.push(case);
 
         // "missing authorization"
-        let case = ServiceBusConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             entity_path: Some("fake"),
             shared_access_signature: None,
@@ -493,7 +493,7 @@ mod tests {
         cases.push(case);
 
         // "SAS and key specified"
-        let case = ServiceBusConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             entity_path: Some("fake"),
             shared_access_signature: Some("fake"),
@@ -503,7 +503,7 @@ mod tests {
         cases.push(case);
 
         // "SAS and shared key name specified"
-        let case = ServiceBusConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             entity_path: Some("fake"),
             shared_access_signature: Some("fake"),
@@ -513,7 +513,7 @@ mod tests {
         cases.push(case);
 
         // "only shared key name specified"
-        let case = ServiceBusConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             entity_path: Some("fake"),
             shared_access_signature: None,
@@ -523,7 +523,7 @@ mod tests {
         cases.push(case);
 
         // "only shared key specified"
-        let case = ServiceBusConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             entity_path: Some("fake"),
             shared_access_signature: None,
@@ -542,7 +542,7 @@ mod tests {
         let sas_key_name = "sasName";
         let shared_access_signature = "fakeSAS";
         let connection_string = format!("Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};SharedAccessKey={sas_key};SharedAccessSignature={shared_access_signature}");
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -565,7 +565,7 @@ mod tests {
         let sas_key_name = "sasName";
         let shared_access_signature = "fakeSAS";
         let connection_string = format!("Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};SharedAccessKey={sas_key};EntityPath={event_hub};SharedAccessSignature={shared_access_signature}");
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -596,7 +596,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!(";Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};SharedAccessKey={sas_key};EntityPath={event_hub}");
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -614,7 +614,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!("Endpoint=sb://{endpoint}; SharedAccessKeyName={sas_key_name}; SharedAccessKey={sas_key}; EntityPath={event_hub}");
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -632,7 +632,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!("Endpoint = sb://{endpoint};SharedAccessKeyName ={sas_key_name};SharedAccessKey= {sas_key}; EntityPath  =  {event_hub}");
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -659,7 +659,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!("Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};Unknown=INVALID;SharedAccessKey={sas_key};EntityPath={event_hub};Trailing=WHOAREYOU");
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -683,7 +683,7 @@ mod tests {
 
         for endpoint_value in endpoint_values {
             let connection_string = format!("Endpoint={};EntityPath=dummy", endpoint_value);
-            let parsed = ServiceBusConnectionStringProperties::parse(&connection_string).unwrap();
+            let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
             assert_eq!(
                 parsed.endpoint().and_then(|url| url.host_str()),
@@ -696,7 +696,7 @@ mod tests {
     fn parse_does_not_allow_an_invalid_endpoint_format() {
         let endpoint = "test.endpoint.com";
         let connection_string = format!("Endpoint={}", endpoint);
-        let result = ServiceBusConnectionStringProperties::parse(&connection_string);
+        let result = ConnectionStringProperties::parse(&connection_string);
         assert!(result.is_err());
     }
 
@@ -712,7 +712,7 @@ mod tests {
         ];
 
         for test_case in test_cases {
-            let result = ServiceBusConnectionStringProperties::parse(test_case);
+            let result = ConnectionStringProperties::parse(test_case);
             assert_eq!(result, Err(FormatError::InvalidConnectionString));
         }
     }
@@ -729,7 +729,7 @@ mod tests {
 
     #[test]
     fn to_connection_string_produces_the_connection_string_for_shared_access_signatures() {
-        let properties = ServiceBusConnectionStringProperties {
+        let properties = ConnectionStringProperties {
             endpoint: Some("sb://place.endpoint.ext".parse().unwrap()),
             entity_path: Some("HubName"),
             shared_access_signature: Some("FaKe#$1324@@"),
@@ -742,14 +742,14 @@ mod tests {
         let connection_string = connection_string.unwrap();
         assert!(!connection_string.is_empty());
 
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string);
+        let parsed = ConnectionStringProperties::parse(&connection_string);
         assert!(parsed.is_ok());
         assert_eq!(properties, parsed.unwrap());
     }
 
     #[test]
     fn to_connection_string_produces_the_connection_string_for_shared_keys() {
-        let properties = ServiceBusConnectionStringProperties {
+        let properties = ConnectionStringProperties {
             endpoint: Some("sb://place.endpoint.ext".parse().unwrap()),
             entity_path: Some("HubName"),
             shared_access_signature: None,
@@ -762,7 +762,7 @@ mod tests {
         let connection_string = connection_string.unwrap();
         assert!(!connection_string.is_empty());
 
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string);
+        let parsed = ConnectionStringProperties::parse(&connection_string);
         assert!(parsed.is_ok());
         assert_eq!(properties, parsed.unwrap());
     }
@@ -777,7 +777,7 @@ mod tests {
 
         for scheme in schemes {
             let endpoint = format!("{}myhub.servicebus.windows.net", scheme);
-            let properties = ServiceBusConnectionStringProperties {
+            let properties = ConnectionStringProperties {
                 endpoint: Some(url::Url::parse(&endpoint).unwrap()),
                 entity_path: Some("HubName"),
                 shared_access_signature: None,
@@ -793,7 +793,7 @@ mod tests {
     #[test]
     fn to_connection_string_returns_ok_with_servicebus_endpoint_scheme() {
         let endpoint = "sb://myhub.servicebus.windows.net";
-        let properties = ServiceBusConnectionStringProperties {
+        let properties = ConnectionStringProperties {
             endpoint: Some(url::Url::parse(endpoint).unwrap()),
             entity_path: Some("HubName"),
             shared_access_signature: None,
@@ -805,7 +805,7 @@ mod tests {
         assert!(connection_string.is_ok());
         let connection_string = connection_string.unwrap();
 
-        let parsed = ServiceBusConnectionStringProperties::parse(&connection_string);
+        let parsed = ConnectionStringProperties::parse(&connection_string);
         assert!(parsed.is_ok());
         assert_eq!(properties, parsed.unwrap());
     }
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     fn to_connection_string_allows_shared_access_key_authorization() {
         let fake_connection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]";
-        let properties = ServiceBusConnectionStringProperties::parse(fake_connection).unwrap();
+        let properties = ConnectionStringProperties::parse(fake_connection).unwrap();
 
         assert!(properties.to_connection_string().is_ok());
     }
@@ -822,7 +822,7 @@ mod tests {
     fn to_connection_string_allows_shared_access_signature_authorization() {
         let fake_connection =
             "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessSignature=[not_real]";
-        let properties = ServiceBusConnectionStringProperties::parse(fake_connection).unwrap();
+        let properties = ConnectionStringProperties::parse(fake_connection).unwrap();
 
         assert!(properties.to_connection_string().is_ok());
     }

--- a/src/primitives/service_bus_message.rs
+++ b/src/primitives/service_bus_message.rs
@@ -6,7 +6,8 @@ use std::time::Duration as StdDuration;
 
 use fe2o3_amqp_types::{
     messaging::{
-        annotations::OwnedKey, ApplicationProperties, Body, Data, Message as AmqpMessage, MessageAnnotations,
+        annotations::OwnedKey, ApplicationProperties, Body, Data, Message as AmqpMessage,
+        MessageAnnotations,
     },
     primitives::Binary,
 };

--- a/src/primitives/service_bus_message_state.rs
+++ b/src/primitives/service_bus_message_state.rs
@@ -1,12 +1,12 @@
-//! Defines the [`ServiceBusMessageState`] enum.
+//! Defines the [`MessageState`] enum.
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::ServiceBusReceivedMessage;
+use crate::ReceivedMessage;
 
-/// Represents the message state of the [`ServiceBusReceivedMessage`]
+/// Represents the message state of the [`ReceivedMessage`]
 #[derive(Debug)]
-pub enum ServiceBusMessageState {
+pub enum MessageState {
     /// Specifies an active message state.
     Active = 0,
 
@@ -18,24 +18,24 @@ pub enum ServiceBusMessageState {
 }
 
 // azservicebus.message.go #L399
-impl Default for ServiceBusMessageState {
+impl Default for MessageState {
     fn default() -> Self {
         Self::Active
     }
 }
 
-impl From<i64> for ServiceBusMessageState {
+impl From<i64> for MessageState {
     fn from(value: i64) -> Self {
         match value {
-            1 => ServiceBusMessageState::Deferred,
-            2 => ServiceBusMessageState::Scheduled,
-            _ => ServiceBusMessageState::Active,
+            1 => MessageState::Deferred,
+            2 => MessageState::Scheduled,
+            _ => MessageState::Active,
         }
     }
 }
 
-impl From<ServiceBusMessageState> for i64 {
-    fn from(value: ServiceBusMessageState) -> Self {
+impl From<MessageState> for i64 {
+    fn from(value: MessageState) -> Self {
         value as i64
     }
 }

--- a/src/primitives/service_bus_peeked_message.rs
+++ b/src/primitives/service_bus_peeked_message.rs
@@ -1,4 +1,4 @@
-//! Defines the [`ServiceBusPeekedMessage`] struct.
+//! Defines the [`PeekedMessage`] struct.
 
 use std::borrow::Cow;
 use std::time::Duration as StdDuration;
@@ -23,22 +23,22 @@ use crate::{
     constants::{DEFAULT_OFFSET_DATE_TIME, MAX_OFFSET_DATE_TIME},
 };
 
-use super::service_bus_message_state::ServiceBusMessageState;
+use super::service_bus_message_state::MessageState;
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::ServiceBusReceivedMessage;
+use crate::ReceivedMessage;
 
 /// A peeked message from a Service Bus queue or topic.
 #[derive(Debug)]
-pub struct ServiceBusPeekedMessage {
+pub struct PeekedMessage {
     pub(crate) raw_amqp_message: Message<Body<Value>>,
 }
 
-impl ServiceBusPeekedMessage {
+impl PeekedMessage {
     /// Gets the raw Amqp message data that was transmitted over the wire. This can be used to
     /// enable scenarios that require reading AMQP header, footer, property, or annotation data that
-    /// is not exposed as top level properties in the [`ServiceBusReceivedMessage`].
+    /// is not exposed as top level properties in the [`ReceivedMessage`].
     pub fn raw_amqp_message(&self) -> &Message<Body<Value>> {
         &self.raw_amqp_message
     }
@@ -334,20 +334,20 @@ impl ServiceBusPeekedMessage {
     /// The state of the message can be Active, Deferred, or Scheduled. Deferred messages have
     /// Deferred state, scheduled messages have Scheduled state, all other messages have Active
     /// state.
-    pub fn state(&self) -> ServiceBusMessageState {
+    pub fn state(&self) -> MessageState {
         self.raw_amqp_message
             .message_annotations
             .as_ref()
             .and_then(|m| m.get(&MESSAGE_STATE_NAME as &dyn AnnotationKey))
             .map(|value| match value {
-                Value::Long(val) => ServiceBusMessageState::from(*val),
+                Value::Long(val) => MessageState::from(*val),
                 _ => unreachable!("Expecting a Long"),
             })
             .unwrap_or_default()
     }
 }
 
-impl std::fmt::Display for ServiceBusPeekedMessage {
+impl std::fmt::Display for PeekedMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.message_id() {
             Some(id) => write!(f, "{{MessageId:{}}}", id),

--- a/src/primitives/service_bus_retry_mode.rs
+++ b/src/primitives/service_bus_retry_mode.rs
@@ -3,7 +3,7 @@
 /// The type of approach to apply when calculating the delay
 /// between retry attempts.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ServiceBusRetryMode {
+pub enum RetryMode {
     /// Retry attempts happen at fixed intervals; each delay is a consistent duration.
     Fixed,
 
@@ -11,7 +11,7 @@ pub enum ServiceBusRetryMode {
     Exponential,
 }
 
-impl Default for ServiceBusRetryMode {
+impl Default for RetryMode {
     fn default() -> Self {
         Self::Exponential
     }

--- a/src/primitives/service_bus_retry_options.rs
+++ b/src/primitives/service_bus_retry_options.rs
@@ -1,8 +1,8 @@
-//! Defines the [`ServiceBusRetryOptions`] struct.
+//! Defines the [`RetryOptions`] struct.
 
 use std::time::Duration;
 
-use super::service_bus_retry_mode::ServiceBusRetryMode;
+use super::service_bus_retry_mode::RetryMode;
 
 const RETRIES_MAX: u32 = 100;
 const DELAY_MIN: Duration = Duration::from_millis(1);
@@ -34,31 +34,31 @@ pub enum OutOfRange<T> {
 /// The set of options that can be specified to influence how
 /// retry attempts are made, and a failure is eligible to be retried.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ServiceBusRetryOptions {
+pub struct RetryOptions {
     /// The approach to use for calculating retry delays.
-    pub mode: ServiceBusRetryMode,
+    pub mode: RetryMode,
 
     /// The maximum number of retry attempts before considering the associated operation to have
-    /// failed. Default to [`ServiceBusRetryOptions::DEFAULT_MAX_RETRIES`]
+    /// failed. Default to [`RetryOptions::DEFAULT_MAX_RETRIES`]
     pub max_retries: u32,
 
     /// The delay or backoff factor to apply between retry attempts. Default to
-    /// [`ServiceBusRetryOptions::DEFAULT_DELAY`]
+    /// [`RetryOptions::DEFAULT_DELAY`]
     pub delay: Duration,
 
     /// The maximum delay to allow between retry attempts. Default to
-    /// [`ServiceBusRetryOptions::DEFAULT_MAX_DELAY`]
+    /// [`RetryOptions::DEFAULT_MAX_DELAY`]
     pub max_delay: Duration,
 
     /// The maximum duration to wait for an operation, per attempt. Default to
-    /// [`ServiceBusRetryOptions::DEFAULT_TRY_TIMEOUT`]
+    /// [`RetryOptions::DEFAULT_TRY_TIMEOUT`]
     pub try_timeout: Duration,
 }
 
-impl Default for ServiceBusRetryOptions {
+impl Default for RetryOptions {
     fn default() -> Self {
         Self {
-            mode: ServiceBusRetryMode::default(),
+            mode: RetryMode::default(),
             max_retries: Self::DEFAULT_MAX_RETRIES,
             delay: Self::DEFAULT_DELAY,
             max_delay: Self::DEFAULT_MAX_DELAY,
@@ -67,26 +67,26 @@ impl Default for ServiceBusRetryOptions {
     }
 }
 
-impl ServiceBusRetryOptions {
-    /// Default value for [`ServiceBusRetryOptions::max_retries`].
+impl RetryOptions {
+    /// Default value for [`RetryOptions::max_retries`].
     pub const DEFAULT_MAX_RETRIES: u32 = 3;
 
-    /// Default value for [`ServiceBusRetryOptions::delay`].
+    /// Default value for [`RetryOptions::delay`].
     pub const DEFAULT_DELAY: Duration = Duration::from_millis(800);
 
-    /// Default value for [`ServiceBusRetryOptions::max_delay`].
+    /// Default value for [`RetryOptions::max_delay`].
     pub const DEFAULT_MAX_DELAY: Duration = Duration::from_secs(60);
 
-    /// Default value for [`ServiceBusRetryOptions::try_timeout`].
+    /// Default value for [`RetryOptions::try_timeout`].
     pub const DEFAULT_TRY_TIMEOUT: Duration = Duration::from_secs(60);
 
     /// The approach to use for calculating retry delays.
-    pub fn mode(&self) -> &ServiceBusRetryMode {
+    pub fn mode(&self) -> &RetryMode {
         &self.mode
     }
 
     /// The approach to use for calculating retry delays.
-    pub fn set_mode(&mut self, mode: ServiceBusRetryMode) {
+    pub fn set_mode(&mut self, mode: RetryMode) {
         self.mode = mode;
     }
 

--- a/src/primitives/service_bus_retry_policy.rs
+++ b/src/primitives/service_bus_retry_policy.rs
@@ -83,15 +83,9 @@ pub trait ServiceBusRetryPolicyState {
 ///
 /// This trait currently is simple a marker trait that acts as the trait bound for the retry policy
 /// generic parameter on the Client.
-pub trait ServiceBusRetryPolicyExt:
-    RetryPolicy + From<RetryOptions> + Send + Sync
-{
-}
+pub trait ServiceBusRetryPolicyExt: RetryPolicy + From<RetryOptions> + Send + Sync {}
 
-impl<T> ServiceBusRetryPolicyExt for T where
-    T: RetryPolicy + From<RetryOptions> + Send + Sync
-{
-}
+impl<T> ServiceBusRetryPolicyExt for T where T: RetryPolicy + From<RetryOptions> + Send + Sync {}
 
 /// Runs the operation with the retry policy.
 ///

--- a/src/primitives/service_bus_retry_policy.rs
+++ b/src/primitives/service_bus_retry_policy.rs
@@ -5,7 +5,7 @@ use std::time::Duration as StdDuration;
 use fe2o3_amqp::link::SendError;
 use fe2o3_amqp_management::error::Error as ManagementError;
 
-use super::service_bus_retry_options::ServiceBusRetryOptions;
+use super::service_bus_retry_options::RetryOptions;
 
 pub(crate) static SERVER_BUSY_BASE_SLEEP_TIME: StdDuration = StdDuration::from_secs(10);
 
@@ -39,9 +39,9 @@ pub(crate) fn should_try_recover_from_management_error(
 /// It is recommended that developers without advanced needs not implement custom retry
 /// policies but instead configure the default policy by specifying the desired set of
 /// retry options when creating one of the Service Bus clients.
-pub trait ServiceBusRetryPolicy: std::fmt::Debug + Send {
+pub trait RetryPolicy: std::fmt::Debug + Send {
     /// Gets the retry options for the policy.
-    fn options(&self) -> &ServiceBusRetryOptions;
+    fn options(&self) -> &RetryOptions;
 
     /// Gets the state for the policy.
     fn state(&self) -> &dyn ServiceBusRetryPolicyState;
@@ -82,14 +82,14 @@ pub trait ServiceBusRetryPolicyState {
 /// Extension trait for retry policies.
 ///
 /// This trait currently is simple a marker trait that acts as the trait bound for the retry policy
-/// generic parameter on the ServiceBusClient.
+/// generic parameter on the Client.
 pub trait ServiceBusRetryPolicyExt:
-    ServiceBusRetryPolicy + From<ServiceBusRetryOptions> + Send + Sync
+    RetryPolicy + From<RetryOptions> + Send + Sync
 {
 }
 
 impl<T> ServiceBusRetryPolicyExt for T where
-    T: ServiceBusRetryPolicy + From<ServiceBusRetryOptions> + Send + Sync
+    T: RetryPolicy + From<RetryOptions> + Send + Sync
 {
 }
 

--- a/src/primitives/service_bus_transport_type.rs
+++ b/src/primitives/service_bus_transport_type.rs
@@ -3,7 +3,7 @@
 /// Specifies the type of protocol and transport that will be used for communicating with Azure
 /// Service Bus.
 #[derive(Debug, Default, Clone, Copy)]
-pub enum ServiceBusTransportType {
+pub enum TransportType {
     /// The connection uses the AMQP protocol over TCP.
     #[cfg_attr(not(target_arch = "wasm32"), default)]
     #[cfg(not(target_arch = "wasm32"))]
@@ -15,7 +15,7 @@ pub enum ServiceBusTransportType {
     AmqpWebSocket,
 }
 
-impl ServiceBusTransportType {
+impl TransportType {
     pub(crate) const AMQP_SCHEME: &'static str = "amqps";
     pub(crate) const WEBSOCKET_SCHEME: &'static str = "wss";
 
@@ -23,8 +23,8 @@ impl ServiceBusTransportType {
     pub fn url_scheme(&self) -> &str {
         match self {
             #[cfg(not(target_arch = "wasm32"))]
-            ServiceBusTransportType::AmqpTcp => Self::AMQP_SCHEME,
-            ServiceBusTransportType::AmqpWebSocket => Self::WEBSOCKET_SCHEME,
+            TransportType::AmqpTcp => Self::AMQP_SCHEME,
+            TransportType::AmqpWebSocket => Self::WEBSOCKET_SCHEME,
         }
     }
 }

--- a/src/receiver/service_bus_receive_mode.rs
+++ b/src/receiver/service_bus_receive_mode.rs
@@ -2,12 +2,12 @@
 
 /// The mode in which to receive messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ServiceBusReceiveMode {
+pub enum ReceiveMode {
     /// Once a message is received in this mode, the receiver has a lock on the message for a
     /// particular duration. If the message is not settled by this time, it lands back on Service
     /// Bus to be fetched by the next receive operation.
     ///
-    /// This is the default value for [`ServiceBusReceiveMode`], and should be used for
+    /// This is the default value for [`ReceiveMode`], and should be used for
     /// guaranteed delivery.
     PeekLock,
 
@@ -16,7 +16,7 @@ pub enum ServiceBusReceiveMode {
     ReceiveAndDelete,
 }
 
-impl Default for ServiceBusReceiveMode {
+impl Default for ReceiveMode {
     fn default() -> Self {
         Self::PeekLock
     }

--- a/src/rule_manager/service_bus_rule_manager.rs
+++ b/src/rule_manager/service_bus_rule_manager.rs
@@ -11,13 +11,13 @@ use crate::{
     core::TransportRuleManager, util::IntoAzureCoreError,
 };
 
-/// A `ServiceBusRuleManager` is used to manage rules for a subscription.
+/// A `RuleManager` is used to manage rules for a subscription.
 #[derive(Debug)]
-pub struct ServiceBusRuleManager {
+pub struct RuleManager {
     pub(crate) inner: AmqpRuleManager,
 }
 
-impl ServiceBusRuleManager {
+impl RuleManager {
     const MAX_RULES_PER_REQUEST: i32 = 100;
 
     /// Get the ID to identify this client.

--- a/src/sender/service_bus_message_batch.rs
+++ b/src/sender/service_bus_message_batch.rs
@@ -1,16 +1,16 @@
-//! Implements `ServiceBusMessageBatch`.
+//! Implements `MessageBatch`.
 
-use fe2o3_amqp_types::messaging::{Data, Message};
+use fe2o3_amqp_types::messaging::{Data, Message as AmqpMessage};
 
 use crate::{
     amqp::{amqp_message_batch::AmqpMessageBatch, error::TryAddMessageError},
     core::TransportMessageBatch,
-    ServiceBusMessage,
+    Message,
 };
 
 // Conditional import for docs.rs
 #[cfg(docsrs)]
-use crate::ServiceBusSender;
+use crate::Sender;
 
 /// The set of options that can be specified to influence the way in which an service bus message
 /// batch behaves and is sent to the Queue/Topic.
@@ -20,10 +20,10 @@ pub struct CreateMessageBatchOptions {
     pub max_size_in_bytes: Option<u64>,
 }
 
-/// A set of [`ServiceBusMessage`] with size constraints known up-front, intended to be sent to the
+/// A set of [`Message`] with size constraints known up-front, intended to be sent to the
 /// Queue/Topic as a single batch.
 ///
-/// A [`ServiceBusMessageBatch`] can be created using [`ServiceBusSender::create_message_batch`].
+/// A [`MessageBatch`] can be created using [`Sender::create_message_batch`].
 /// Messages can be added to the batch using the [`Self::try_add_message`] method on the batch.
 ///
 /// # Examples
@@ -40,11 +40,11 @@ pub struct CreateMessageBatchOptions {
 /// sender.send_message_batch(message_batch).await.unwrap();
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ServiceBusMessageBatch {
+pub struct MessageBatch {
     pub(crate) inner: AmqpMessageBatch,
 }
 
-impl ServiceBusMessageBatch {
+impl MessageBatch {
     /// The maximum size of the batch, in bytes.
     pub fn max_size_in_bytes(&self) -> u64 {
         self.inner.max_size_in_bytes()
@@ -65,20 +65,20 @@ impl ServiceBusMessageBatch {
         self.inner.is_empty()
     }
 
-    /// Attempts to add a [`ServiceBusMessage`] to the [`ServiceBusMessageBatch`].
+    /// Attempts to add a [`Message`] to the [`MessageBatch`].
     ///
     /// Returns an error if the message is too large to fit in the batch or
     /// if the message fails to serialize. The original message can be recovered
     /// from the error.
     pub fn try_add_message(
         &mut self,
-        message: impl Into<ServiceBusMessage>,
+        message: impl Into<Message>,
     ) -> Result<(), TryAddMessageError> {
         self.inner.try_add_message(message.into())
     }
 
     /// Iterate over the messages in the batch.
-    pub fn iter(&self) -> std::slice::Iter<'_, Message<Data>> {
+    pub fn iter(&self) -> std::slice::Iter<'_, AmqpMessage<Data>> {
         self.inner.iter()
     }
 

--- a/tests/client_live_tests.rs
+++ b/tests/client_live_tests.rs
@@ -37,8 +37,8 @@ mod macros;
 cfg_not_wasm32! {
     use azservicebus::{
         authorization::AzureNamedKeyCredential,
-        ServiceBusClient, ServiceBusClientOptions,
-        ServiceBusTransportType,
+        Client, ClientOptions,
+        TransportType,
     };
 
     mod common;
@@ -49,10 +49,10 @@ cfg_not_wasm32! {
         setup_dotenv();
 
         let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING").unwrap();
-        let mut option = ServiceBusClientOptions::default();
-        option.transport_type = ServiceBusTransportType::AmqpTcp;
+        let mut option = ClientOptions::default();
+        option.transport_type = TransportType::AmqpTcp;
 
-        let mut client = ServiceBusClient::new_from_connection_string(&connection_string, option)
+        let mut client = Client::new_from_connection_string(&connection_string, option)
             .await
             .unwrap();
 
@@ -73,10 +73,10 @@ cfg_not_wasm32! {
         setup_dotenv();
 
         let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING").unwrap();
-        let mut option = ServiceBusClientOptions::default();
-        option.transport_type = ServiceBusTransportType::AmqpWebSocket;
+        let mut option = ClientOptions::default();
+        option.transport_type = TransportType::AmqpWebSocket;
 
-        let mut client = ServiceBusClient::new_from_connection_string(&connection_string, option)
+        let mut client = Client::new_from_connection_string(&connection_string, option)
             .await
             .unwrap();
 
@@ -103,7 +103,7 @@ cfg_not_wasm32! {
 
         let credential = AzureNamedKeyCredential::new(key_name, key);
         let mut client =
-            ServiceBusClient::new_from_named_key_credential(namespace, credential, Default::default())
+            Client::new_from_named_key_credential(namespace, credential, Default::default())
                 .await
                 .unwrap();
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,9 +3,8 @@
 use std::time::Duration as StdDuration;
 
 use azservicebus::{
-    Client, ClientOptions, Message, PeekedMessage,
-    ReceivedMessage, ReceiverOptions, RetryOptions, ServiceBusSender,
-    SenderOptions, SessionReceiverOptions,
+    Client, ClientOptions, Message, PeekedMessage, ReceivedMessage, ReceiverOptions, RetryOptions,
+    SenderOptions, ServiceBusSender, SessionReceiverOptions,
 };
 use time::OffsetDateTime;
 
@@ -33,8 +32,7 @@ pub async fn create_client_and_send_messages_separately_to_queue_or_topic(
     sender_options: SenderOptions,
     messages: impl Iterator<Item = impl Into<Message>>,
 ) -> Result<(), anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut sender = client
         .create_sender(queue_or_topic_name, sender_options)
         .await?;
@@ -66,8 +64,7 @@ pub async fn create_client_and_receive_messages_from_queue(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, receiver_options)
         .await?;
@@ -95,8 +92,7 @@ pub async fn create_client_and_receive_sessionful_messages_from_queue(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = match session_id {
         Some(session_id) => {
             client
@@ -133,8 +129,7 @@ pub async fn create_client_and_receive_messages_from_subscription(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_subscription(topic_name, subscription_name, receiver_options)
         .await?;
@@ -163,8 +158,7 @@ pub async fn create_client_and_receive_sessionful_messages_from_subscription(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .accept_session_for_subscription(
             topic_name,
@@ -196,8 +190,7 @@ pub async fn create_client_and_abandon_messages_from_queue(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, receiver_options)
         .await?;
@@ -224,8 +217,7 @@ pub async fn create_client_and_deadletter_messages_from_queue(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, receiver_options)
         .await?;
@@ -254,8 +246,7 @@ pub async fn create_client_and_schedule_messages(
     messages: impl Iterator<Item = impl Into<Message>> + ExactSizeIterator + Send,
     enqueue_time: OffsetDateTime,
 ) -> Result<Vec<i64>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut sender = client.create_sender(queue_name, sender_options).await?;
 
     let sequence_numbers = sender.schedule_messages(messages, enqueue_time).await?;
@@ -273,8 +264,7 @@ pub async fn create_client_and_peek_messages(
     receiver_options: ReceiverOptions,
     max_messages: u32,
 ) -> Result<Vec<PeekedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, receiver_options)
         .await?;
@@ -295,8 +285,7 @@ pub async fn create_client_and_defer_messages(
     max_messages: u32,
     max_wait_time: Option<StdDuration>,
 ) -> Result<Vec<i64>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, receiver_options)
         .await?;
@@ -322,8 +311,7 @@ pub async fn create_client_and_receive_deferred_messages(
     receiver_options: ReceiverOptions,
     sequence_numbers: Vec<i64>,
 ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
-    let mut client =
-        Client::new_from_connection_string(connection_string, client_options).await?;
+    let mut client = Client::new_from_connection_string(connection_string, client_options).await?;
     let mut receiver = client
         .create_receiver_for_queue(queue_name, receiver_options)
         .await?;

--- a/tests/long_tests.rs
+++ b/tests/long_tests.rs
@@ -8,7 +8,7 @@
 mod macros;
 
 cfg_not_wasm32! {
-    use azservicebus::{ServiceBusReceivedMessage, ServiceBusReceiver, ServiceBusSender};
+    use azservicebus::{ReceivedMessage, ServiceBusReceiver, ServiceBusSender};
 
     mod common;
 
@@ -32,7 +32,7 @@ cfg_not_wasm32! {
     async fn receive_and_complete_incoming_messages(
         mut receiver: ServiceBusReceiver,
         total: usize,
-    ) -> Result<Vec<ServiceBusReceivedMessage>, anyhow::Error> {
+    ) -> Result<Vec<ReceivedMessage>, anyhow::Error> {
         let mut total_received = 0;
         let mut received = Vec::new();
         while total_received < total {
@@ -62,14 +62,14 @@ cfg_not_wasm32! {
         // cargo test --test long_tests --features test_e2e -- --ignored send_to_queue_every_minute_for_two_hour --exact --nocapture
         // ```
 
-        use azservicebus::{ServiceBusClient};
+        use azservicebus::{Client};
 
         common::setup_dotenv();
 
         let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING").unwrap();
         let queue_name = std::env::var("SERVICE_BUS_QUEUE").unwrap();
 
-        let mut client = ServiceBusClient::new_from_connection_string(
+        let mut client = Client::new_from_connection_string(
             &connection_string,
             Default::default(),
         )

--- a/tests/queue_live_tests.rs
+++ b/tests/queue_live_tests.rs
@@ -36,9 +36,9 @@ mod macros;
 
 cfg_not_wasm32! {
     use azservicebus::{
-        ServiceBusClient, ServiceBusClientOptions,
+        Client, ClientOptions,
         SubQueue,
-        ServiceBusMessage, ServiceBusReceiverOptions,
+        Message, ReceiverOptions,
     };
     use std::time::Duration as StdDuration;
 
@@ -150,7 +150,7 @@ cfg_not_wasm32! {
         let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
         let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-        let message = ServiceBusMessage::new("test message");
+        let message = Message::new("test message");
         let messages = std::iter::once(message);
         let total = messages.len();
 
@@ -184,7 +184,7 @@ cfg_not_wasm32! {
         let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
         let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
-        let message = ServiceBusMessage::new("test message");
+        let message = Message::new("test message");
         let messages = std::iter::once(message);
         let total = messages.len();
 
@@ -197,7 +197,7 @@ cfg_not_wasm32! {
         )
         .await?;
 
-        let mut receiver_client_options = ServiceBusClientOptions::default();
+        let mut receiver_client_options = ClientOptions::default();
         receiver_client_options.retry_options = common::zero_retry_options();
 
         let received = common::create_client_and_receive_messages_from_queue(
@@ -225,9 +225,9 @@ cfg_not_wasm32! {
 
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = vec![
-            ServiceBusMessage::new(expected[0]),
-            ServiceBusMessage::new(expected[1]),
-            ServiceBusMessage::new(expected[2]),
+            Message::new(expected[0]),
+            Message::new(expected[1]),
+            Message::new(expected[2]),
         ];
         let total = messages.len();
 
@@ -267,9 +267,9 @@ cfg_not_wasm32! {
 
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = vec![
-            ServiceBusMessage::new(expected[0]),
-            ServiceBusMessage::new(expected[1]),
-            ServiceBusMessage::new(expected[2]),
+            Message::new(expected[0]),
+            Message::new(expected[1]),
+            Message::new(expected[2]),
         ];
         let max_messages = messages.len() as u32;
 
@@ -282,7 +282,7 @@ cfg_not_wasm32! {
         )
         .await?;
 
-        let mut receiver_options = ServiceBusReceiverOptions::default();
+        let mut receiver_options = ReceiverOptions::default();
         receiver_options.prefetch_count = max_messages;
         common::create_client_and_receive_messages_from_queue(
             &connection_string,
@@ -304,7 +304,7 @@ cfg_not_wasm32! {
 
         let expected = ["test message 1", "test message 2", "test message 3"];
 
-        let mut client = ServiceBusClient::new_from_connection_string(&connection_string, Default::default()).await?;
+        let mut client = Client::new_from_connection_string(&connection_string, Default::default()).await?;
         let mut sender = client
             .create_sender(&queue_name, Default::default())
             .await?;
@@ -342,7 +342,7 @@ cfg_not_wasm32! {
 
         let expected = ["test message 1", "test message 2", "test message 3"];
 
-        let mut client = ServiceBusClient::new_from_connection_string(&connection_string, Default::default()).await?;
+        let mut client = Client::new_from_connection_string(&connection_string, Default::default()).await?;
         let mut sender = client
             .create_sender(&queue_name, Default::default())
             .await?;
@@ -354,7 +354,7 @@ cfg_not_wasm32! {
         }
         sender.send_message_batch(message_batch).await?;
 
-        let mut receiving_client_options = ServiceBusClientOptions::default();
+        let mut receiving_client_options = ClientOptions::default();
         receiving_client_options.retry_options = common::zero_retry_options();
 
         let received = common::create_client_and_receive_messages_from_queue(
@@ -385,7 +385,7 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let session_id = "test_session";
         let messages = expected.iter().map(|message| {
-            let mut message = ServiceBusMessage::new(message.as_bytes());
+            let mut message = Message::new(message.as_bytes());
             message.set_session_id(String::from(session_id)).unwrap();
             message
         });
@@ -461,7 +461,7 @@ cfg_not_wasm32! {
 
         // Send 2nd session id first
         let messages = expected_for_session_id_2.iter().map(|message| {
-            let mut message = ServiceBusMessage::new(message.as_bytes());
+            let mut message = Message::new(message.as_bytes());
             message.set_session_id(String::from(session_id_2)).unwrap();
             message
         });
@@ -476,7 +476,7 @@ cfg_not_wasm32! {
 
         // Send 1st session id last
         let messages = expected_for_session_id_1.iter().map(|message| {
-            let mut message = ServiceBusMessage::new(*message);
+            let mut message = Message::new(*message);
             message.set_session_id(String::from(session_id_1)).unwrap(); // length must not exceed max length
             message
         });
@@ -524,12 +524,12 @@ cfg_not_wasm32! {
         let connection_string = std::env::var("SERVICE_BUS_CONNECTION_STRING")?;
         let queue_name = std::env::var("SERVICE_BUS_SESSION_QUEUE")?;
 
-        let mut client = ServiceBusClient::new_from_connection_string(connection_string, Default::default()).await?;
+        let mut client = Client::new_from_connection_string(connection_string, Default::default()).await?;
         let mut sender = client
             .create_sender(&queue_name, Default::default())
             .await?;
 
-        let mut session_message = ServiceBusMessage::new("test message");
+        let mut session_message = Message::new("test message");
         session_message.set_session_id(String::from("test_session_1"))?;
         sender.send_message(session_message).await?;
 
@@ -557,7 +557,7 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = expected
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
 
         common::create_client_and_send_messages_separately_to_queue_or_topic(
             &connection_string,
@@ -605,7 +605,7 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = expected
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
 
         common::create_client_and_send_messages_separately_to_queue_or_topic(
             &connection_string,
@@ -626,7 +626,7 @@ cfg_not_wasm32! {
         )
         .await?;
 
-        let mut receiver_options = ServiceBusReceiverOptions::default();
+        let mut receiver_options = ReceiverOptions::default();
         receiver_options.sub_queue = SubQueue::DeadLetter;
         let received = common::create_client_and_receive_messages_from_queue(
             &connection_string,
@@ -655,7 +655,7 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = expected
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
 
         let wait_time = StdDuration::from_secs(30);
         let enqueue_time = OffsetDateTime::now_utc() + wait_time;
@@ -700,9 +700,9 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = expected
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
 
-        let mut client = ServiceBusClient::new_from_connection_string(&connection_string, Default::default()).await?;
+        let mut client = Client::new_from_connection_string(&connection_string, Default::default()).await?;
         let mut sender = client
             .create_sender(&queue_name, Default::default())
             .await?;
@@ -716,7 +716,7 @@ cfg_not_wasm32! {
         }
 
         tokio::time::sleep(wait_time).await;
-        let mut client_options = ServiceBusClientOptions::default();
+        let mut client_options = ClientOptions::default();
         client_options.retry_options = common::zero_retry_options();
 
         let received = common::create_client_and_receive_messages_from_queue(
@@ -741,7 +741,7 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = expected
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
 
         common::create_client_and_send_messages_separately_to_queue_or_topic(
             &connection_string,
@@ -808,7 +808,7 @@ cfg_not_wasm32! {
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = expected
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
 
         common::create_client_and_send_messages_separately_to_queue_or_topic(
             &connection_string,
@@ -857,7 +857,7 @@ cfg_not_wasm32! {
         let message = ["test message 1"];
         let messages = message
             .iter()
-            .map(|message| ServiceBusMessage::new(*message));
+            .map(|message| Message::new(*message));
         common::create_client_and_send_messages_separately_to_queue_or_topic(
             &connection_string,
             Default::default(),
@@ -867,7 +867,7 @@ cfg_not_wasm32! {
         )
         .await?;
 
-        let mut client = ServiceBusClient::new_from_connection_string(&connection_string, Default::default()).await?;
+        let mut client = Client::new_from_connection_string(&connection_string, Default::default()).await?;
         let mut receiver = client
             .create_receiver_for_queue(queue_name, Default::default())
             .await?;
@@ -901,7 +901,7 @@ cfg_not_wasm32! {
         let queue_name = std::env::var("SERVICE_BUS_QUEUE")?;
 
         let mut client =
-            ServiceBusClient::new_from_connection_string(connection_string, ServiceBusClientOptions::default()).await?;
+            Client::new_from_connection_string(connection_string, ClientOptions::default()).await?;
 
         // Create a sender and then send a batch of messages
         let mut sender = client
@@ -909,7 +909,7 @@ cfg_not_wasm32! {
             .await?;
 
         let time_to_live = Duration::from_secs(600);
-        let mut message = ServiceBusMessage::new("test message 1");
+        let mut message = Message::new("test message 1");
         message.set_time_to_live(time_to_live)?;
         sender.send_message(message).await?;
 

--- a/tests/topic_live_tests.rs
+++ b/tests/topic_live_tests.rs
@@ -35,7 +35,7 @@
 mod macros;
 
 cfg_not_wasm32! {
-    use azservicebus::{ServiceBusMessage, ServiceBusReceiverOptions};
+    use azservicebus::{Message, ReceiverOptions};
 
     mod common;
     use common::setup_dotenv;
@@ -80,7 +80,7 @@ cfg_not_wasm32! {
         let subscription_name = std::env::var("SERVICE_BUS_SUBSCRIPTION")?;
 
         let message_body = b"test message";
-        let message = ServiceBusMessage::new(&message_body[..]);
+        let message = Message::new(&message_body[..]);
         let messages = std::iter::once(message);
         let max_messages = messages.len() as u32;
 
@@ -119,9 +119,9 @@ cfg_not_wasm32! {
 
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = vec![
-            ServiceBusMessage::new(expected[0]),
-            ServiceBusMessage::new(expected[1]),
-            ServiceBusMessage::new(expected[2]),
+            Message::new(expected[0]),
+            Message::new(expected[1]),
+            Message::new(expected[2]),
         ];
         let total = messages.len();
 
@@ -163,9 +163,9 @@ cfg_not_wasm32! {
 
         let expected = ["test message 1", "test message 2", "test message 3"];
         let messages = vec![
-            ServiceBusMessage::new(expected[0]),
-            ServiceBusMessage::new(expected[1]),
-            ServiceBusMessage::new(expected[2]),
+            Message::new(expected[0]),
+            Message::new(expected[1]),
+            Message::new(expected[2]),
         ];
         let total = messages.len();
 
@@ -178,7 +178,7 @@ cfg_not_wasm32! {
         )
         .await?;
 
-        let receiver_option = ServiceBusReceiverOptions {
+        let receiver_option = ReceiverOptions {
             prefetch_count: total as u32,
             ..Default::default()
         };
@@ -248,7 +248,7 @@ cfg_not_wasm32! {
 
         // Send 2nd session messages first to ensure that the 1st session is not auto-received
         let messages = expected_for_session_id_2.iter().map(|m| {
-            let mut message = ServiceBusMessage::new(m.as_bytes());
+            let mut message = Message::new(m.as_bytes());
             message.set_session_id(String::from(session_id_2)).unwrap();
             message
         });
@@ -263,7 +263,7 @@ cfg_not_wasm32! {
 
         // Send 1st session messages next
         let messages = expected_for_session_id_1.iter().map(|m| {
-            let mut message = ServiceBusMessage::new(m.as_bytes());
+            let mut message = Message::new(m.as_bytes());
             message.set_session_id(String::from(session_id_1)).unwrap();
             message
         });
@@ -309,7 +309,7 @@ cfg_not_wasm32! {
         let topic_name = std::env::var("SERVICE_BUS_RULE_FILTER_TEST_TOPIC")?;
         let subscription_name = std::env::var("SERVICE_BUS_RULE_FILTER_TEST_SUBSCRIPTION")?;
 
-        let mut client = ServiceBusClient::new_from_connection_string(connection_string, Default::default()).await?;
+        let mut client = Client::new_from_connection_string(connection_string, Default::default()).await?;
         let mut rule_manager = client
             .create_rule_manager(topic_name, subscription_name)
             .await?;


### PR DESCRIPTION
Removed "ServiceBus" prefix from most pub type names (eg. `ServiceBusClient` -> `Client`, `ServiceBusReceiver` -> `Receiver`)