### PR TITLE
feat: support unsecured connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,9 @@ env_logger = "0.11"
 azure_identity = "0.20"
 
 [features]
-default = ["native-tls"]
+default = [
+    "native-tls",
+]
 
 # CI tests related features
 test_e2e = [] # This enables tests under the `sdk/messaging_servicebus/tests` directory
@@ -87,3 +89,6 @@ transaction = ["fe2o3-amqp/transaction"]
 
 rustls = ["fe2o3-amqp/rustls", "fe2o3-amqp-ws/rustls-tls-webpki-roots"]
 native-tls = ["fe2o3-amqp/native-tls", "fe2o3-amqp-ws/native-tls"]
+
+# unsecured connection for testing with emulator
+unsecured = []

--- a/src/client/service_bus_client.rs
+++ b/src/client/service_bus_client.rs
@@ -18,7 +18,7 @@ use crate::{
     diagnostics,
     entity_name_formatter::{self, format_entity_path},
     primitives::{
-        service_bus_connection::{build_connection_resource, ServiceBusConnection},
+        service_bus_connection::{build_connection_resource, build_unsecured_connection_resource, ServiceBusConnection},
         service_bus_retry_options::ServiceBusRetryOptions,
         service_bus_retry_policy::ServiceBusRetryPolicyExt,
         service_bus_transport_type::ServiceBusTransportType,
@@ -216,6 +216,117 @@ where
     }
 }
 
+cfg_unsecured! {
+    impl<RP> WithCustomRetryPolicy<RP> {
+        /// Use an unsecured connection for the client.
+        pub fn unsecured() -> Unsecured<RP> {
+            Unsecured {
+                retry_policy: PhantomData,
+            }
+        }
+    }
+
+    /// Type state for [`ServiceBusClient`] indicating that the client will be created over an
+    /// unsecured connection.
+    #[derive(Debug)]
+    pub struct Unsecured<RP> {
+        retry_policy: PhantomData<RP>,
+    }
+
+    impl<RP> Unsecured<RP>
+    where
+        RP: ServiceBusRetryPolicyExt + Send + Sync + 'static,
+    {
+        /// Similar to [`WithCustomRetryPolicy::new_from_connection_string`], but creates a
+        /// [`ServiceBusClient`] over an unsecured connection.
+        pub async fn new_from_connection_string<'a>(
+            self,
+            connection_string: impl Into<Cow<'a, str>>,
+            options: ServiceBusClientOptions,
+        ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+            let connection_string = connection_string.into();
+            let identifier = options.identifier.clone();
+            let connection = ServiceBusConnection::new(connection_string, options).await?;
+            let identifier = identifier.unwrap_or_else(|| {
+                diagnostics::utilities::generate_identifier(connection.fully_qualified_namespace())
+            });
+            Ok(ServiceBusClient {
+                identifier,
+                connection,
+            })
+        }
+
+        /// Similar to [`WithCustomRetryPolicy::new_from_named_key_credential`], but creates a
+        /// [`ServiceBusClient`] over an unsecured connection.
+        pub async fn new_from_named_key_credential(
+            self,
+            fully_qualified_namespace: impl Into<String>,
+            credential: AzureNamedKeyCredential,
+            options: ServiceBusClientOptions,
+        ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+            let fully_qualified_namespace = fully_qualified_namespace.into();
+            let signuture_resource = build_unsecured_connection_resource(
+                &options.transport_type,
+                Some(&fully_qualified_namespace),
+                None,
+            )?;
+            let shared_access_credential =
+                SharedAccessCredential::try_from_named_key_credential(credential, signuture_resource)?;
+            self.new_from_credential(fully_qualified_namespace, shared_access_credential, options).await
+        }
+
+        /// Similar to [`WithCustomRetryPolicy::new_from_sas_credential`], but creates a
+        /// [`ServiceBusClient`] over an unsecured connection.
+        pub async fn new_from_sas_credential(
+            self,
+            fully_qualified_namespace: impl Into<String>,
+            credential: AzureSasCredential,
+            options: ServiceBusClientOptions,
+        ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+            let shared_access_credential = SharedAccessCredential::try_from_sas_credential(credential)?;
+            self.new_from_credential(fully_qualified_namespace, shared_access_credential, options).await
+        }
+
+        /// Similar to [`WithCustomRetryPolicy::new_from_token_credential`], but creates a
+        /// [`ServiceBusClient`] over an unsecured connection.
+        pub async fn new_from_token_credential(
+            self,
+            fully_qualified_namespace: impl Into<String>,
+            credential: impl TokenCredential + 'static,
+            options: ServiceBusClientOptions,
+        ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+            let credential = ServiceBusTokenCredential::new(credential);
+            self.new_from_credential(fully_qualified_namespace, credential, options)
+                .await
+        }
+
+        /// Similar to [`WithCustomRetryPolicy::new_from_credential`], but creates a
+        /// [`ServiceBusClient`] over an unsecured connection.
+        pub async fn new_from_credential(
+            self,
+            fully_qualified_namespace: impl Into<String>,
+            credential: impl Into<ServiceBusTokenCredential>,
+            options: ServiceBusClientOptions,
+        ) -> Result<ServiceBusClient<RP>, azure_core::Error> {
+            let fully_qualified_namespace = fully_qualified_namespace.into();
+            let identifier = options.identifier.clone().unwrap_or_else(|| {
+                diagnostics::utilities::generate_identifier(&fully_qualified_namespace)
+            });
+            let credential = credential.into();
+            let connection = ServiceBusConnection::new_unsecured_from_credential(
+                fully_qualified_namespace,
+                credential,
+                options,
+            )
+            .await?;
+            Ok(ServiceBusClient {
+                identifier,
+                connection,
+            })
+        }
+    }
+}
+
 /// The [`ServiceBusClient`] is the top-level client through which all Service Bus entities can be
 /// interacted with. Any lower level types retrieved from here, such as [`ServiceBusSender`] and
 /// [`ServiceBusReceiver`] will share the same AMQP connection. Disposing the [`ServiceBusClient`]
@@ -261,6 +372,15 @@ impl ServiceBusClient<BasicRetryPolicy> {
     pub fn with_custom_retry_policy<RP>() -> WithCustomRetryPolicy<RP> {
         WithCustomRetryPolicy {
             retry_policy: PhantomData,
+        }
+    }
+
+    cfg_unsecured! {
+        /// Use an unsecured connection for the client.
+        pub fn unsecured() -> Unsecured<BasicRetryPolicy> {
+            Unsecured {
+                retry_policy: PhantomData,
+            }
         }
     }
 

--- a/src/core/transport_client.rs
+++ b/src/core/transport_client.rs
@@ -60,6 +60,16 @@ pub(crate) trait TransportClient: Sized + Sealed {
         retry_timeout: StdDuration,
     ) -> Result<Self, Self::CreateClientError>;
 
+    cfg_unsecured! {
+        async fn create_unsecured_transport_client(
+            host: &str,
+            credential: ServiceBusTokenCredential,
+            transport_type: ServiceBusTransportType,
+            custom_endpoint: Option<Url>,
+            retry_timeout: StdDuration,
+        ) -> Result<Self, Self::CreateClientError>;
+    }
+
     /// Get the transport type
     fn transport_type(&self) -> ServiceBusTransportType;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_enum_variant, clippy::result_large_err)] // TODO: refactor to avoid large enum variant
+
 //! An unofficial and experimental AMQP 1.0 client for Azure Service Bus.
 //!
 //! This crate follows a similar structure to the dotnet sdk

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,3 +32,13 @@ macro_rules! cfg_either_rustls_or_native_tls {
         )*
     }
 }
+
+macro_rules! cfg_unsecured {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "unsecured")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unsecured")))]
+            $item
+        )*
+    }
+}

--- a/src/primitives/service_bus_connection.rs
+++ b/src/primitives/service_bus_connection.rs
@@ -35,37 +35,53 @@ macro_rules! ok_if_not_none_or_empty {
     };
 }
 
+macro_rules! build_connection_resource_impl {
+    ($transport_type:ident, $fully_qualified_namespace:ident, $entity_name:ident, $url_scheme_fn:ident) => {
+        match $fully_qualified_namespace {
+            Some(fqn) => {
+                let mut builder = Url::parse(&format!("{}://{}", $transport_type.$url_scheme_fn(), fqn))?;
+                builder.set_path($entity_name.unwrap_or_default());
+                builder
+                    .set_port(None)
+                    .map_err(|_| ArgumentError("Unable to set port to None".to_string()))?;
+                builder.set_fragment(None);
+                builder
+                    .set_password(None)
+                    .map_err(|_| ArgumentError("Unable to set password to None".to_string()))?;
+                builder.set_username("").map_err(|_| {
+                    ArgumentError("Unable to set username to empty string".to_string())
+                })?;
+
+                // Removes the trailing slash if and only if there is one and it is not the first
+                // character
+                builder
+                    .path_segments_mut()
+                    .map_err(|_| url::ParseError::RelativeUrlWithCannotBeABaseBase)?
+                    .pop_if_empty();
+
+                Ok(builder.to_string().to_lowercase())
+            }
+            None => Ok(String::new()),
+        }
+    };
+}
+
 /// Builds the audience of the connection for use in the signature.
 pub(crate) fn build_connection_resource(
     transport_type: &ServiceBusTransportType,
     fully_qualified_namespace: Option<&str>,
     entity_name: Option<&str>,
 ) -> Result<String, Error> {
-    match fully_qualified_namespace {
-        Some(fqn) => {
-            let mut builder = Url::parse(&format!("{}://{}", transport_type.url_scheme(), fqn))?;
-            builder.set_path(entity_name.unwrap_or_default());
-            builder
-                .set_port(None)
-                .map_err(|_| ArgumentError("Unable to set port to None".to_string()))?;
-            builder.set_fragment(None);
-            builder
-                .set_password(None)
-                .map_err(|_| ArgumentError("Unable to set password to None".to_string()))?;
-            builder.set_username("").map_err(|_| {
-                ArgumentError("Unable to set username to empty string".to_string())
-            })?;
+    build_connection_resource_impl!(transport_type, fully_qualified_namespace, entity_name, url_scheme)
+}
 
-            // Removes the trailing slash if and only if there is one and it is not the first
-            // character
-            builder
-                .path_segments_mut()
-                .map_err(|_| url::ParseError::RelativeUrlWithCannotBeABaseBase)?
-                .pop_if_empty();
-
-            Ok(builder.to_string().to_lowercase())
-        }
-        None => Ok(String::new()),
+cfg_unsecured! {
+    pub(crate) fn build_unsecured_connection_resource(
+        transport_type: &ServiceBusTransportType,
+        fully_qualified_namespace: Option<&str>,
+        entity_name: Option<&str>,
+    ) -> Result<String, Error> {
+        build_connection_resource_impl!(transport_type, fully_qualified_namespace, entity_name, unsecured_url_scheme)
     }
 }
 
@@ -279,6 +295,30 @@ where
             retry_options: options.retry_options,
             inner_client,
         })
+    }
+
+    cfg_unsecured! {
+        pub(crate) async fn new_unsecured_from_credential(
+            fully_qualified_namespace: String,
+            credential: impl Into<ServiceBusTokenCredential>,
+            options: ServiceBusClientOptions,
+        ) -> Result<ServiceBusConnection<C>, C::CreateClientError> {
+            let token_credential: ServiceBusTokenCredential = credential.into();
+            let inner_client = C::create_unsecured_transport_client(
+                &fully_qualified_namespace,
+                token_credential,
+                options.transport_type,
+                options.custom_endpoint_address,
+                options.retry_options.try_timeout,
+            )
+            .await?;
+    
+            Ok(ServiceBusConnection {
+                fully_qualified_namespace,
+                retry_options: options.retry_options,
+                inner_client,
+            })
+        }
     }
 
     pub async fn dispose(self) -> Result<(), C::DisposeError> {

--- a/src/primitives/service_bus_transport_type.rs
+++ b/src/primitives/service_bus_transport_type.rs
@@ -27,4 +27,18 @@ impl ServiceBusTransportType {
             ServiceBusTransportType::AmqpWebSocket => Self::WEBSOCKET_SCHEME,
         }
     }
+
+    cfg_unsecured!{
+        pub(crate) const UNSECURED_AMQP_SCHEME: &'static str = "amqp";
+        pub(crate) const UNSECURED_WEBSOCKET_SCHEME: &'static str = "ws";
+
+        /// Returns the URI scheme for the transport type without the secure layer.
+        pub fn unsecured_url_scheme(&self) -> &str {
+            match self {
+                #[cfg(not(target_arch = "wasm32"))]
+                ServiceBusTransportType::AmqpTcp => Self::UNSECURED_AMQP_SCHEME,
+                ServiceBusTransportType::AmqpWebSocket => Self::UNSECURED_WEBSOCKET_SCHEME,
+            }
+        }
+    }
 }


### PR DESCRIPTION
close: #32 

Support for unsecured connection can be enabled by toggling the `unsecured` feature in `Cargo.toml` and by using the `unsecured()` function, eg.

```rust
let client = ServiceBusClient::unsecured()
    .new_from_connection_string(
        "<NAMESPACE-CONNECTION-STRING>",
        ServiceBusClientOptions::default(),
    )
    .await?;
```